### PR TITLE
Handled security warnings by GitHub

### DIFF
--- a/examples/custom-scripts/NetBox_DNS_Exporter.py
+++ b/examples/custom-scripts/NetBox_DNS_Exporter.py
@@ -54,7 +54,7 @@ $TTL {{ zone.default_ttl }}
 {{ record.name.ljust(32) }}    {{ (record.ttl|string if record.ttl is not none else '').ljust(8) }} IN {{ record.type.ljust(8) }}    {{ record.value }}
 {% endfor %}\
 '''
-    jinja_env = Environment(loader=DictLoader({"zone_file": zone_template}))
+    jinja_env = Environment(loader=DictLoader({"zone_file": zone_template}), autoescape=True)
     template = jinja_env.get_template("zone_file")
 
     def run(self, data, commit):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.8"
 dnspython = "^2.2.1"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^5.2"
+pytest = "^7.2"
 black = "^21.8b0"
 
 [build-system]


### PR DESCRIPTION
This PR raises the minimum version of the pytest library to 7.2 and sets the Jinja 2 environment in one of the sample scripts to use `autoescape=True`.