### PR TITLE
Add a new configuration option to enforce unique records

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -371,3 +371,25 @@ PLUGINS_CONFIG = {
 ```
 
 This feature is disabled by default.
+
+## Uniqueness of Records
+
+There is no standard requiring that records need to be unique within a zone, so it's perfectly legal to create records with the same name, type and value to a zone where the same record already exists. Use cases for this are, however, very rare, and on the other hand allowing duplicate records can cause problems with bulk imports and automated updates to zones.
+
+For this reason there is a configuration setting that makes NetBox DNS enforce uniqueness of records in a way that no record can be created with a given name, type and value in a zone where an active record with the same values already exists:
+
+```
+PLUGINS_CONFIG = {
+    'netbox_dns': {
+        ...
+        'enforce_unique_records': True,
+        ...
+    },
+}
+```
+
+This feature is disabled by default.
+
+Note that setting this option to `True` in an existing NetBox installation does not affect duplicate records that are already present in the database, and so it might make sense to clean them up manually or by script. It won't be possible to save any changes to either of the duplicate records as long as the other one is still present and active.
+
+It can also be a useful strategy to set `enforce_unique_records` to `True` while doing bulk imports, then set it to the default value `False` after the imports are done if importing is a one-off task.

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -28,6 +28,7 @@ class DNSConfig(PluginConfig):
         ],
         "tolerate_non_rfc1035_types": [],
         "enable_root_zones": False,
+        "enforce_unique_records": False,
     }
     base_url = "netbox-dns"
 

--- a/netbox_dns/tests/record/test_uniqueness.py
+++ b/netbox_dns/tests/record/test_uniqueness.py
@@ -1,0 +1,103 @@
+from django.test import TestCase, override_settings
+from django.core.exceptions import ValidationError
+
+from netbox_dns.models import Zone, Record, RecordTypeChoices, NameServer
+
+
+class RecordValidationTest(TestCase):
+    zone_data = {
+        "default_ttl": 86400,
+        "soa_rname": "hostmaster.example.com",
+        "soa_refresh": 172800,
+        "soa_retry": 7200,
+        "soa_expire": 2592000,
+        "soa_ttl": 86400,
+        "soa_minimum": 3600,
+        "soa_serial": 1,
+    }
+
+    record_data = {
+        "ttl": 86400,
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.nameserver = NameServer.objects.create(name="ns1.example.com")
+        cls.zones = [
+            Zone(name="zone1.example.com", **cls.zone_data, soa_mname=cls.nameserver),
+        ]
+        Zone.objects.bulk_create(cls.zones)
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                "enforce_unique_records": False,
+            }
+        }
+    )
+    def test_create_unique_records(self):
+        f_zone = self.zones[0]
+
+        records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+            {"name": "test2", "type": RecordTypeChoices.A, "value": "10.0.2.42"},
+        ]
+
+        for record in records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+            f_record.save()
+
+    def test_create_duplicate_records_ok(self):
+        f_zone = self.zones[0]
+
+        records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+        ]
+
+        for record in records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+            f_record.save()
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                "enforce_unique_records": True,
+            }
+        }
+    )
+    def test_create_duplicate_records_fail(self):
+        f_zone = self.zones[0]
+
+        records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+        ]
+
+        duplicate_records = [
+            {"name": "test1", "type": RecordTypeChoices.A, "value": "10.0.1.42"},
+        ]
+
+        for record in records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+            f_record.save()
+
+        for record in duplicate_records:
+            f_record = Record(
+                zone=f_zone,
+                **record,
+                **self.record_data,
+            )
+            with self.assertRaises(ValidationError):
+                f_record.save()


### PR DESCRIPTION
fixes #38

This PR creates a new configuration option `enforce_unique_records` (disabled by default) that inhibits the addition of RRs to a zone when an active RR with the same name, type and value already exists.