### PR TITLE
Fix hostname validation for PTR records with wildcard targets

### DIFF
--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -39,10 +39,15 @@ class NameValidationTest(TestCase):
                 soa_mname=cls.nameserver,
                 name="zone240" + 22 * ".987654321" + ".example.com.",
             ),
+            Zone(
+                **cls.zone_data,
+                soa_mname=cls.nameserver,
+                name="f.e.e.b.d.a.e.d.0.8.e.f.ip6.arpa",
+            ),
         )
         Zone.objects.bulk_create(cls.zones)
         for zone in cls.zones:
-            zone.clean()
+            zone.save()
 
     def test_name_validation_ok(self):
         records = (

--- a/netbox_dns/validators.py
+++ b/netbox_dns/validators.py
@@ -15,9 +15,9 @@ def has_invalid_double_dash(name):
 
 def validate_fqdn(name):
     if get_plugin_config("netbox_dns", "tolerate_underscores_in_hostnames"):
-        regex = rf"^{UNDERSCORE_LABEL}(\.{UNDERSCORE_LABEL})+\.?$"
+        regex = rf"^(\*|{UNDERSCORE_LABEL})(\.{UNDERSCORE_LABEL})+\.?$"
     else:
-        regex = rf"^{LABEL}(\.{LABEL})+\.?$"
+        regex = rf"^(\*|{LABEL})(\.{LABEL})+\.?$"
 
     if not re.match(regex, name, flags=re.IGNORECASE) or has_invalid_double_dash(name):
         raise ValidationError(f"Not a valid fully qualified DNS host name")


### PR DESCRIPTION
fixes #45

PTR records having wildcard values did not validate as legal FQDN.

This went unnoticed because the tests did not create PTR records. Fixed the tests and the issue.