### PR TITLE
Fixed import statements for NetBox 3.5.8

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -7,7 +7,7 @@ class DNSConfig(PluginConfig):
     name = "netbox_dns"
     verbose_name = "NetBox DNS"
     description = "NetBox plugin for DNS data"
-    min_version = "3.5"
+    min_version = "3.5.8"
     version = __version__
     author = "Peter Eckel"
     author_email = "pe-netbox-plugin-dns@hindenburgring.com"

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -43,7 +43,7 @@ from netbox_dns.validators import (
     validate_extended_hostname,
 )
 
-from extras.plugins import get_plugin_config
+from extras.plugins.utils import get_plugin_config
 
 
 class NameServer(NetBoxModel):

--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -1,6 +1,7 @@
 from django.db.models.functions import Length
 
-from extras.plugins import PluginTemplateExtension, get_plugin_config
+from extras.plugins.utils import get_plugin_config
+from extras.plugins import PluginTemplateExtension
 
 from netbox_dns.models import Record, RecordTypeChoices, Zone
 from netbox_dns.tables import RelatedRecordTable, RelatedZoneTable

--- a/netbox_dns/utilities.py
+++ b/netbox_dns/utilities.py
@@ -4,7 +4,7 @@ from dns import name as dns_name
 from dns.exception import DNSException
 from netaddr import IPNetwork, AddrFormatError
 
-from extras.plugins import get_plugin_config
+from extras.plugins.utils import get_plugin_config
 
 
 class NameFormatError(Exception):

--- a/netbox_dns/validators.py
+++ b/netbox_dns/validators.py
@@ -2,7 +2,7 @@ import re
 
 from django.core.exceptions import ValidationError
 
-from extras.plugins import get_plugin_config
+from extras.plugins.utils import get_plugin_config
 
 LABEL = r"[a-z0-9][a-z0-9-]*(?<!-)"
 UNDERSCORE_LABEL = r"[a-z0-9][a-z0-9-_]*(?<![-_])"


### PR DESCRIPTION
Set minimum NetBox version to 3.5.8 to avoid installing on lower versions