### PR TITLE
Fixed migration dependency for NetBox 3.5.x

### DIFF
--- a/netbox_dns/migrations/0024_tenancy.py
+++ b/netbox_dns/migrations/0024_tenancy.py
@@ -6,7 +6,7 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("tenancy", "0011_contactassignment_tags"),
+        ("tenancy", "0010_tenant_relax_uniqueness"),
         ("netbox_dns", "0023_alter_record_value"),
     ]
 


### PR DESCRIPTION
Migration `netbox_dns.0024_tenancy` was created by `makemigrations` with a dependency on `tenancy.0011_contactassignment_tags`.

Unfortunately, that migration was only introduced with NetBox 3.6.0, so the dependency breaks compatibility with 3.5.x (> 3.5.8). This PR changes the dependency so NetBox 3.5 should be properly supported again.