### PR TITLE
Removed re-indexing migration

### DIFF
--- a/netbox_dns/migrations/0022_search.py
+++ b/netbox_dns/migrations/0022_search.py
@@ -1,29 +1,11 @@
 import sys
 
-from packaging import version
-
-from django.core import management
 from django.db import migrations
-from django.conf import settings
-
-
-def reindex(apps, schema_editor):
-    if "test" not in sys.argv:
-        if version.parse(settings.VERSION) >= version.parse("3.4.2"):
-            management.call_command("reindex", "netbox_dns")
-        else:
-            management.call_command("reindex", "netbox_dns.view")
-            management.call_command("reindex", "netbox_dns.nameserver")
-            management.call_command("reindex", "netbox_dns.zone")
-            management.call_command("reindex", "netbox_dns.record")
 
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("extras", "0083_search"),
         ("netbox_dns", "0021_record_ip_address"),
     ]
 
-    operations = [
-        migrations.RunPython(code=reindex, reverse_code=migrations.RunPython.noop),
-    ]
+    operations = []


### PR DESCRIPTION
After global search was introduced, A migration reindexing existing NetBox DNS tables was added. Unfortunately that migration fails when new columns are added to the database in later migrations as model and database schema are in mismatch when that is the case.

Changed the reindexing to a noop. It will be gone when the next squash happens.