### PR TITLE
Introduce experimental IPAM-DNS coupling feature

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -11,6 +11,7 @@ class DNSConfig(PluginConfig):
     version = __version__
     author = "Peter Eckel"
     author_email = "pe-netbox-plugin-dns@hindenburgring.com"
+    middleware = ['netbox_dns.middleware.IpamCouplingMiddleware']
     required_settings = []
     default_settings = {
         "zone_default_ttl": 86400,
@@ -21,6 +22,7 @@ class DNSConfig(PluginConfig):
         "zone_soa_expire": 2592000,
         "zone_soa_minimum": 3600,
         "feature_ipam_integration": False,
+        "feature_ipam_coupling": False,
         "tolerate_underscores_in_hostnames": False,
         "tolerate_leading_underscore_types": [
             "TXT",

--- a/netbox_dns/middleware.py
+++ b/netbox_dns/middleware.py
@@ -1,0 +1,184 @@
+from django.db import transaction
+from django.db.models import signals
+from django.core.exceptions import MiddlewareNotUsed, PermissionDenied
+
+from ipam.models.ip import IPAddress
+from extras.plugins import get_plugin_config
+from netbox_dns.models import Zone, Record, RecordTypeChoices
+from utilities.exceptions import PermissionsViolation, AbortRequest
+from utilities.permissions import resolve_permission
+
+class Action:
+    def __init__(self, request):
+        self.request = request
+
+    #
+    # Check permission to create DNS record before IP address creation
+    # NB: If IP address is created *before* DNS record is allowed it's too late
+    # → permission check must be done at pre-save, and an exception
+    # must be raised to prevent IP creation.
+    #
+    def pre_save(self, sender, **kwargs):
+        if kwargs.get("update_fields"):
+            return
+
+        ip = kwargs.get("instance")
+        name = ip.custom_field_data.get("name")
+        zone_id = ip.custom_field_data.get("zone")
+
+        # Handle new IP Address only; name and zone must both be defined
+        if ip.id is None and name and zone_id:
+            zone = Zone.objects.get(id=zone_id)
+            if ip.family == 6:
+                type = RecordTypeChoices.AAAA 
+            else:
+                type = RecordTypeChoices.A
+            value = str(ip.address.ip)
+
+            # Create a DNS record *without saving* in order to check permissions
+            record = Record(name=name, zone=zone, type=type, value=value)
+            user = self.request.user
+            check_record_permission(user, record, 'netbox_dns.add_record')
+
+    #
+    # Handle DNS record operation after IPAddress has been created or modified
+    #
+    def post_save(self, sender, **kwargs):
+
+        # Do not process specific field update (eg. dns_hostname modify) 
+        if kwargs.get("update_fields"):
+            return
+
+        user = self.request.user
+        ip = kwargs.get("instance")
+        name = ip.custom_field_data.get("name")
+        zone_id = ip.custom_field_data.get("zone")
+        zone = Zone.objects.get(id=zone_id) if zone_id else None
+
+        # Clear the other field if one is empty, which is inconsistent
+        if (name and not zone) or (zone and not name):
+            zone = name = None
+
+        # Delete DNS record because name and zone have been removed
+        if name == zone == None:
+            # Get current dns record
+            if record_id := ip.custom_field_data.get("dns_record"):
+                record = Record.objects.get(id=record_id)
+                # Clear all custom fields related to DNS if permission ok
+                check_record_permission(user, record, 'netbox_dns.delete_record')
+
+                ip.dns_name = ""
+                ip.custom_field_data["dns_record"] = None
+                ip.custom_field_data["name"] = ""
+                ip.custom_field_data["zone"] = None
+                ip.save(update_fields=['custom_field_data', 'dns_name'])
+                record.delete()
+
+        # Modify or add DNS record
+        else:
+            # Does the object already have a DNS record ?
+            # Modify DNS record
+            if record_id := ip.custom_field_data.get("dns_record"):
+                record = Record.objects.get(id=record_id)
+                record.name, record.zone = name, zone
+                record.value = str(ip.address.ip)
+                record.type = RecordTypeChoices.AAAA if ip.family == 6 else RecordTypeChoices.A
+                check_record_permission(user, record, 'netbox_dns.change_record')
+                record.save()
+                # Update dns_name field with FQDN
+                ip.dns_name = f"{name}.{zone.name}"
+                ip.save(update_fields=['dns_name'])
+
+            # create DNS record
+            else:
+                record = Record(name = name, zone = zone, \
+                    type = RecordTypeChoices.AAAA if ip.family == 6 else RecordTypeChoices.A, \
+                    value = str(ip.address.ip), managed = True)
+
+                check_record_permission(user, record, 'netbox_dns.add_record', commit=True)
+                # link record to IP Address 
+                ip.custom_field_data["dns_record"] = record.id
+                # cosmetic: update dns_name field with FQDN
+                ip.dns_name = f"{name}.{zone.name}"
+                # Save modified field in IP after creating record
+                ip.save(update_fields=['custom_field_data', 'dns_name'])
+
+
+    #
+    # Delete DNS record before deleting IP address 
+    #
+    def pre_delete(self, sender, **kwargs):
+
+        # Get IPAddress instance
+        ip = kwargs.get("instance")
+        # Get DNS record if any
+        record_id = ip.custom_field_data.get("dns_record")
+        if record_id:
+            # Delete DNS record if it already exists
+            record = Record.objects.get(id=record_id)
+            user = self.request.user
+            check_record_permission(user, record, 'netbox_dns.delete_record')
+            record.delete()
+
+#
+# Filter through permissions. Simulate adding the record in the "add" case.
+# NB: Side-effect if "commit" is set to True → the DNS record is created.
+# This is necessary to avoid the cascading effects of PTR creation.
+#
+def check_record_permission(user, record, perm, commit=False):
+
+    # Check that the user has been granted the required permission(s).
+    action = resolve_permission(perm)[1]
+
+    if not user.has_perm(perm):
+        raise PermissionDenied()
+
+    try:
+        with transaction.atomic():
+            # Save record when adding
+            # Rollback is done at the end of the transaction, unless committed
+            if action == 'add':
+                record.save()
+
+            # Update the view's QuerySet to filter only the permitted objects
+            queryset = Record.objects.all()
+            queryset = queryset.restrict(user, action)
+            # Check that record conforms to permissions 
+            # → must be included in the restricted queryset
+            if not queryset.filter(pk=record.pk).exists():
+                raise PermissionDenied()
+
+            if not commit:
+                raise AbortRequest("Normal Exit")
+
+    # Catch "Normal Exit" without modification, rollback transaction
+    except AbortRequest as e:
+        pass
+
+    except Exception as e:
+        raise e
+
+
+class IpamCouplingMiddleware:
+    def __init__(self, get_response):
+        if not get_plugin_config('netbox_dns', 'feature_ipam_coupling'):
+            raise MiddlewareNotUsed
+
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # connect signals to actions 
+        action = Action(request)
+        connections = [ (signals.pre_save,     action.pre_save),
+                        (signals.post_save,    action.post_save),
+                        (signals.pre_delete,   action.pre_delete)
+        ]
+        for signal, receiver in connections:
+            signal.connect(receiver, sender=IPAddress)
+
+        response = self.get_response(request)
+
+        for signal, receiver in connections:
+            signal.disconnect(receiver)
+
+        return response

--- a/netbox_dns/migrations/0025_ipam_coupling_cf.py
+++ b/netbox_dns/migrations/0025_ipam_coupling_cf.py
@@ -1,0 +1,56 @@
+from django.db import migrations
+from django.contrib.contenttypes.models import ContentType
+
+from extras.models import CustomField
+
+from extras.choices import CustomFieldTypeChoices,CustomFieldVisibilityChoices
+from ipam.models import IPAddress, Prefix
+from netbox_dns.models import Record, RecordTypeChoices, Zone, NameServer
+
+def add_ipam_coupling_cf(apps, schema_editor):
+    # CustomField = apps.get_model("extras", "CustomField")
+    # IPAddress = apps.get_model("ipam", "IPAddress")
+    # Zone = apps.get_model("netbox_dns", "Zone")
+    # Record = apps.get_model("netbox_dns", "Record")
+
+    ipaddress_object_type = ContentType.objects.get_for_model(IPAddress)
+    zone_object_type = ContentType.objects.get_for_model(Zone)
+    record_object_type = ContentType.objects.get_for_model(Record)
+    cf_name = CustomField.objects.create(
+        name = 'name', 
+        type = CustomFieldTypeChoices.TYPE_TEXT,
+        required = False
+    )
+    cf_name.content_types.set([ipaddress_object_type])
+    cf_zone  =  CustomField.objects.create(
+        name = 'zone', 
+        type = CustomFieldTypeChoices.TYPE_OBJECT,
+        object_type = zone_object_type,
+        required = False
+    )
+    cf_zone.content_types.set([ipaddress_object_type])
+    cf_dns_record  =  CustomField.objects.create(
+        name = 'dns_record', 
+        type = CustomFieldTypeChoices.TYPE_OBJECT,
+        object_type = record_object_type,
+        required = False,
+        ui_visibility = CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY
+    )
+    cf_dns_record.content_types.set([ipaddress_object_type])
+
+def delete_ipam_coupling_cf(apps, schema_editor):
+
+    ipaddress_object_type = ContentType.objects.get_for_model(IPAddress)
+    CustomField.objects.get(name='name', content_types=ipaddress_object_type).delete()
+    CustomField.objects.get(name='zone', content_types=ipaddress_object_type).delete()
+    CustomField.objects.get(name='dns_record', content_types=ipaddress_object_type).delete()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_dns", "0023_alter_record_value"),
+    ]
+
+    operations = [
+        migrations.RunPython( add_ipam_coupling_cf, reverse_code=delete_ipam_coupling_cf)
+    ]
+

--- a/netbox_dns/tests/coupling/test_ip_dns_coupling.py
+++ b/netbox_dns/tests/coupling/test_ip_dns_coupling.py
@@ -1,0 +1,230 @@
+from django.urls import reverse
+from django.test import override_settings
+from django.contrib.contenttypes.models import ContentType
+
+from rest_framework import status
+from utilities.testing import APITestCase
+
+from extras.models import CustomField
+from extras.choices import CustomFieldTypeChoices
+from ipam.models import IPAddress, Prefix
+from netaddr import IPNetwork
+from netbox_dns.models import Record, Zone, NameServer, RecordTypeChoices
+
+class IPAddressDNSRecordCouplingTest(APITestCase):
+    network = "10.0.0.0/24"
+    ns = "ns1.example.com"
+    zone_data = {
+        "default_ttl": 86400,
+        "soa_rname": "hostmaster.example.com",
+        "soa_refresh": 172800,
+        "soa_retry": 7200,
+        "soa_expire": 2592000,
+        "soa_ttl": 86400,
+        "soa_minimum": 3600,
+        "soa_serial": 1,
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        # Test data
+        cls.nameserver = NameServer.objects.create(name=cls.ns)
+        cls.zone = Zone.objects.create(name="zone1.example.com", **cls.zone_data, soa_mname=cls.nameserver)
+        cls.zone2 = Zone.objects.create(name="zone2.example.com", **cls.zone_data, soa_mname=cls.nameserver)
+        cls.prefix = Prefix.objects.create(prefix=cls.network)
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_create_ip(self):
+        zone = self.zone
+        name = "test-create"
+        addr = "10.0.0.25/24"
+
+        # Grant permissions to user
+        self.add_permissions('ipam.add_ipaddress')
+        self.add_permissions('netbox_dns.add_record')
+
+        url = reverse('ipam-api:ipaddress-list')
+        data = { "address": addr,
+                 "custom_fields": { "zone": zone.id, "name": name }
+               }
+        response = self.client.post(url, data, format="json", **self.header)
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        # Check if "record" has been created, is managed and has correct name and zone
+        record_id = response.data['custom_fields']['dns_record']['id']
+        record = Record.objects.get(id=record_id)
+        self.assertEqual(record.name, name)
+        self.assertEqual(record.zone.id, zone.id)
+        self.assertTrue(record.managed)
+        # Check value of dns_name
+        ipaddress = IPAddress.objects.get(id=response.data['id'])
+        self.assertEqual(ipaddress.dns_name, f"{name}.{zone.name}")
+
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_create_ip_missing_dns_permission(self):
+        zone = self.zone
+        name = "test-create-ip-missing-dns-perm"
+        addr = "10.0.0.26/24"
+
+        # Grant only IPAddress add permission to user,
+        # and *no* DNS record add permission
+        self.add_permissions('ipam.add_ipaddress')
+
+        url = reverse('ipam-api:ipaddress-list')
+        data = { "address": addr,
+                 "custom_fields": { "zone": zone.id, "name": name }
+               }
+        response = self.client.post(url, data, format="json", **self.header)
+
+        # Should be denied
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        # No IP address should have been created
+        self.assertEqual(IPAddress.objects.filter(address=addr).count(), 0)
+        # No DNS Record should have been created
+        self.assertEqual(Record.objects.filter(name=name,zone_id=zone.id).count(), 0)
+
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_delete_ip(self):
+        zone = self.zone
+        name = "test-delete-ip"
+        addr = IPNetwork("10.0.0.27/24")
+        # Grant delete on both IP address and DNS record
+        self.add_permissions('ipam.delete_ipaddress')
+        self.add_permissions('netbox_dns.delete_record')
+
+        # Create DNS record and IP Address
+        A = RecordTypeChoices.A ; s_addr = str(addr.ip)
+        record = Record.objects.create(name=name,zone=zone,type=A,value=s_addr)
+        ip_address = IPAddress.objects.create(
+          address=addr, dns_name=f'{name}.{zone.name}',
+          custom_field_data={"name":name,"zone":zone.id,"dns_record":record.id})
+
+        # Delete address
+        url = reverse("ipam-api:ipaddress-list") + str(ip_address.id) + '/'
+        response = self.client.delete(url, **self.header)
+        # Check response
+        self.assertTrue(status.is_success(response.status_code))
+        # Check if IP address has been deleted
+        self.assertEqual( IPAddress.objects.filter(id=ip_address.id).count(), 0 )
+        # Check if DNS record has been deleted
+        self.assertEqual( Record.objects.filter(id=record.id).count(), 0 )
+
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_modify_name_existing_ip(self):
+        addr = IPNetwork("10.0.0.27/24")
+        zone = self.zone
+        name = "test-modify-name-existing-ip"
+
+        newname = "newname"
+        zone2 = self.zone2
+
+        # Grant permissions to user
+        self.add_permissions('ipam.change_ipaddress')
+        self.add_permissions('netbox_dns.change_record')
+
+        # Create DNS record
+        A = RecordTypeChoices.A ; s_addr=str(addr.ip)
+        record = Record.objects.create(name=name,zone=zone,type=A,value=s_addr)
+        # Create IP Address
+        ip_address = IPAddress.objects.create(
+          address=addr, dns_name=f'{name}.{zone.name}',
+          custom_field_data={"name":name,"zone":zone.id,"dns_record":record.id})
+
+        # Change name and zone
+        url = reverse("ipam-api:ipaddress-list") + str(ip_address.id) + '/'
+        data = {
+            "custom_fields": { "name": newname, "zone": zone2.id }
+        }
+        response = self.client.patch(url, data, format="json", **self.header)
+
+        # Check response
+        self.assertTrue(status.is_success(response.status_code))
+
+        # Fetch record with name and zone, check if they match
+        record_query = Record.objects.filter(name=newname)
+        record_id = ip_address.custom_field_data.get("dns_record")
+        self.assertEqual(record_query[0].id, record_id)
+
+        # Check value of dns_name
+        ip_address = IPAddress.objects.get(id=ip_address.id)
+        self.assertEqual(ip_address.dns_name, f"{newname}.{zone2.name}")
+
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_modify_name_existing_ip_missing_dns_permission(self):
+        addr = IPNetwork("10.0.0.27/24")
+        zone = self.zone
+        name = "test-modify-name-existing-ip-no-perm"
+
+        newname = "newname"
+        zone2 = self.zone2
+
+        # Grant permissions to user
+        self.add_permissions('ipam.change_ipaddress')
+
+        # Create DNS record
+        A = RecordTypeChoices.A ; s_addr=str(addr.ip)
+        record = Record.objects.create(name=name,zone=zone,type=A,value=s_addr)
+        # Create IP Address
+        ip_address = IPAddress.objects.create(
+          address=addr, dns_name=f'{name}.{zone.name}',
+          custom_field_data={"name":name,"zone":zone.id,"dns_record":record.id})
+
+        # Change name and zone
+        url = reverse("ipam-api:ipaddress-list") + str(ip_address.id) + '/'
+        data = {
+            "custom_fields": { "name": newname, "zone": zone2.id }
+        }
+        response = self.client.patch(url, data, format="json", **self.header)
+
+        # Check response
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Re-read IPAddress object
+        ip_address = IPAddress.objects.get(id=ip_address.id)
+        # Check for no changes
+        record_id = ip_address.custom_field_data.get("dns_record")
+        record_query = Record.objects.filter(name=name)
+        self.assertEqual(record_query[0].id, record_id)
+        self.assertEqual(ip_address.dns_name, f"{name}.{zone.name}")
+
+
+    @override_settings(PLUGINS_CONFIG={'netbox_dns': {'feature_ipam_coupling': True}})
+    def test_clear_name_existing_ip(self):
+        addr = IPNetwork("10.0.0.28/24")
+        zone = self.zone
+        name = "test-clear-name-existing-ip"
+
+        # Grant permissions to user
+        self.add_permissions('ipam.change_ipaddress')
+        self.add_permissions('netbox_dns.delete_record')
+
+        # Create DNS record
+        A = RecordTypeChoices.A ; s_addr=str(addr.ip)
+        record = Record.objects.create(name=name,zone=zone,type=A,value=s_addr)
+        # Create IP Address
+
+        ip_address = IPAddress.objects.create(
+          address=addr, dns_name=f'{name}.{zone.name}',
+          custom_field_data={"name":name,"zone":zone.id,"dns_record":record.id})
+
+        url = reverse("ipam-api:ipaddress-list") + str(ip_address.id) + '/'
+        data = { 'custom_fields': { 'zone': None } }
+        response = self.client.patch(url, data, format='json', **self.header)
+
+        # Check response
+        self.assertTrue(status.is_success(response.status_code))
+        # Check if record has been deleted
+        self.assertEqual(Record.objects.filter(id=record.id).count() ,0)
+        # Re-read IPAddress object
+        ip_address = IPAddress.objects.get(id=ip_address.id)
+        # Check if record_id has been removed
+        record_id = ip_address.custom_field_data.get("dns_record")
+        self.assertEqual(record_id, None)
+        # Check if dns_name is empty
+        self.assertEqual(ip_address.dns_name, f"")
+


### PR DESCRIPTION
(see issue #67)
Three new custom fields are added on IP Address :
- name,
- zone,
- dns_record.

Through a middleware and signals, all IP Address creation and modification are intercepted. Using the new custom fields, the corresponding DNS record is created, modified or deleted accordingly.
Permission on DNS records are enforced.
The IP address "dns_name" field is also updated.