### PR TITLE
Shorten DNS names when creating record string representation

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 logger = logging.getLogger("netbox.config")
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 
 class DNSConfig(PluginConfig):

--- a/netbox_dns/models.py
+++ b/netbox_dns/models.py
@@ -786,6 +786,8 @@ class Record(NetBoxModel):
             )
         except dns_name.IDNAException:
             name = self.name
+        except dns_name.LabelTooLong as exc:
+            name = f"{self.name[:59]}..."
 
         return f"{name} [{self.type}]"
 

--- a/netbox_dns/tests/test_netbox_dns.py
+++ b/netbox_dns/tests/test_netbox_dns.py
@@ -7,7 +7,7 @@ from netbox_dns.tests.custom import APITestCase
 
 class NetBoxDNSVersionTestCase(SimpleTestCase):
     def test_version(self):
-        assert __version__ == "0.20.0"
+        assert __version__ == "0.20.1"
 
 
 class AppTest(APITestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netbox-plugin-dns"
-version = "0.20.0"
+version = "0.20.1"
 description = "NetBox DNS is a NetBox plugin for managing DNS data."
 authors = ["Peter Eckel <pe-netbox-dns@hindenburgring.com>"]
 homepage = "https://github.com/peteeckel/netbox-plugin-dns"


### PR DESCRIPTION
When a record is edited, the title of the record form is set to a version with interpreted IDN characters. This requires parsing the title using `dnspython`. When a record is edited and the edit results in a record name not conforming to DNS naming standards, this conversion fails.

fixes #81