### PR TITLE
Restored compatibility with NetBox < 3.5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NetBox DNS is using the standardized NetBox plugin interface, so it also takes a
 
 ## Requirements
 
-* NetBox 3.5.8 or higher
+* NetBox 3.5.0 or higher
 * Python 3.8 or higher
 
 ## Installation & Configuration

--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -17,7 +17,7 @@ The installation of plugins in general is described in the [NetBox documentation
 ### Requirements
 The installation of NetBox DNS requires a Python interpreter and a working NetBox deployment. Supported versions are currently:
 
-* NetBox 3.5.8 or higher
+* NetBox 3.5.0 or higher
 * Python 3.8 or higher
 
 ### Installation of NetBox DNS

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -1,7 +1,13 @@
 import sys
 
 from extras.plugins import PluginConfig
-from extras.plugins.utils import get_plugin_config
+
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 
 __version__ = "0.20.2"
 
@@ -10,7 +16,7 @@ class DNSConfig(PluginConfig):
     name = "netbox_dns"
     verbose_name = "NetBox DNS"
     description = "NetBox plugin for DNS data"
-    min_version = "3.5.8"
+    min_version = "3.5.0"
     version = __version__
     author = "Peter Eckel"
     author_email = "pe-netbox-plugin-dns@hindenburgring.com"

--- a/netbox_dns/middleware.py
+++ b/netbox_dns/middleware.py
@@ -4,7 +4,13 @@ from django.core.exceptions import MiddlewareNotUsed, PermissionDenied, Validati
 
 from ipam.models import IPAddress
 from ipam.choices import IPAddressStatusChoices
-from extras.plugins.utils import get_plugin_config
+
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 from netbox.signals import post_clean
 from utilities.permissions import resolve_permission
 

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -14,7 +14,13 @@ from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
 from utilities.querysets import RestrictedQuerySet
 from utilities.choices import ChoiceSet
-from extras.plugins.utils import get_plugin_config
+
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 
 from netbox_dns.fields import AddressField
 from netbox_dns.utilities import (

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -20,8 +20,14 @@ from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
 from utilities.querysets import RestrictedQuerySet
 from utilities.choices import ChoiceSet
-from extras.plugins.utils import get_plugin_config
 from ipam.models import IPAddress
+
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 
 from netbox_dns.fields import NetworkField
 from netbox_dns.utilities import (

--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -1,4 +1,9 @@
-from extras.plugins.utils import get_plugin_config
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 from extras.plugins import PluginTemplateExtension
 
 from netbox_dns.models import Record, Zone, View, NameServer

--- a/netbox_dns/utilities.py
+++ b/netbox_dns/utilities.py
@@ -4,7 +4,12 @@ from dns import name as dns_name
 from dns.exception import DNSException
 from netaddr import IPNetwork, AddrFormatError
 
-from extras.plugins.utils import get_plugin_config
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 
 
 class NameFormatError(Exception):

--- a/netbox_dns/validators.py
+++ b/netbox_dns/validators.py
@@ -2,7 +2,12 @@ import re
 
 from django.core.exceptions import ValidationError
 
-from extras.plugins.utils import get_plugin_config
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
 
 LABEL = r"[a-z0-9][a-z0-9-]*(?<!-)"
 UNDERSCORE_LABEL = r"[a-z0-9][a-z0-9-_]*(?<![-_])"


### PR DESCRIPTION
fixes #94

This is not exactly an example of beautiful code, but it solves the compatibility problem with all 3.5.x NetBox releases, so it is the lesser evil than unnecessarily imposing version restrictions.