### PR TITLE
Tolerate underscores even if leading underscores are allowed

### DIFF
--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -186,13 +186,23 @@ class NameValidationTest(TestCase):
         }
     )
     def test_txt_validation_tolerant_ok(self):
-        record = Record.objects.create(
-            name="_dmarc",
-            zone=self.zones[0],
-            type=RecordTypeChoices.TXT,
-            value="v=DMARC1;p=reject",
+        records = (
+            {
+                "name": "_dmarc",
+                "zone": self.zones[0],
+                "type": RecordTypeChoices.TXT,
+                "value": "v=DMARC1;p=reject",
+            },
+            {
+                "name": "key1_op16._domainkey",
+                "zone": self.zones[0],
+                "type": RecordTypeChoices.TXT,
+                "value": "test",
+            },
         )
-        self.assertEqual(record.name, "_dmarc")
+        for record in records:
+            record_object = Record.objects.create(**record)
+            self.assertEqual(record_object.name, record.get("name"))
 
     @override_settings(
         PLUGINS_CONFIG={

--- a/netbox_dns/validators.py
+++ b/netbox_dns/validators.py
@@ -10,8 +10,9 @@ except ImportError:
     from extras.plugins.utils import get_plugin_config
 
 LABEL = r"[a-z0-9][a-z0-9-]*(?<!-)"
-UNDERSCORE_LABEL = r"[a-z0-9][a-z0-9-_]*(?<![-_])"
+TOLERANT_LABEL = r"[a-z0-9][a-z0-9-_]*(?<![-_])"
 LEADING_UNDERSCORE_LABEL = r"[a-z0-9_][a-z0-9-]*(?<!-)"
+TOLERANT_LEADING_UNDERSCORE_LABEL = r"[a-z0-9_][a-z0-9-_]*(?<![-_])"
 
 
 def has_invalid_double_dash(name):
@@ -20,7 +21,7 @@ def has_invalid_double_dash(name):
 
 def validate_fqdn(name):
     if get_plugin_config("netbox_dns", "tolerate_underscores_in_hostnames"):
-        regex = rf"^(\*|{UNDERSCORE_LABEL})(\.{UNDERSCORE_LABEL})+\.?$"
+        regex = rf"^(\*|{TOLERANT_LABEL})(\.{TOLERANT_LABEL})+\.?$"
     else:
         regex = rf"^(\*|{LABEL})(\.{LABEL})+\.?$"
 
@@ -30,9 +31,12 @@ def validate_fqdn(name):
 
 def validate_extended_hostname(name, tolerate_leading_underscores=False):
     if tolerate_leading_underscores:
-        regex = rf"^([*@]|(\*\.)?{LEADING_UNDERSCORE_LABEL}(\.{LEADING_UNDERSCORE_LABEL})*\.?)$"
+        if get_plugin_config("netbox_dns", "tolerate_underscores_in_hostnames"):
+            regex = rf"^([*@]|(\*\.)?{TOLERANT_LEADING_UNDERSCORE_LABEL}(\.{TOLERANT_LEADING_UNDERSCORE_LABEL})*\.?)$"
+        else:
+            regex = rf"^([*@]|(\*\.)?{LEADING_UNDERSCORE_LABEL}(\.{LEADING_UNDERSCORE_LABEL})*\.?)$"
     elif get_plugin_config("netbox_dns", "tolerate_underscores_in_hostnames"):
-        regex = rf"^([*@]|(\*\.)?{UNDERSCORE_LABEL}(\.{UNDERSCORE_LABEL})*\.?)$"
+        regex = rf"^([*@]|(\*\.)?{TOLERANT_LABEL}(\.{TOLERANT_LABEL})*\.?)$"
     else:
         regex = rf"^([*@]|(\*\.)?{LABEL}(\.{LABEL})*\.?)$"
 
@@ -45,7 +49,7 @@ def validate_domain_name(name):
         return
 
     if get_plugin_config("netbox_dns", "tolerate_underscores_in_hostnames"):
-        regex = rf"^{UNDERSCORE_LABEL}(\.{UNDERSCORE_LABEL})*\.?$"
+        regex = rf"^{TOLERANT_LABEL}(\.{TOLERANT_LABEL})*\.?$"
     else:
         regex = rf"^{LABEL}(\.{LABEL})*\.?$"
 


### PR DESCRIPTION
fixes #106

This fixes an issue where `tolerate_underscores_in_hostnames` works for all RR types except the ones for which leading underscores are allowed.