### PR TITLE
Fixed bulk import of Zone, Record, View and NameServer with tags

### DIFF
--- a/netbox_dns/filters/nameserver.py
+++ b/netbox_dns/filters/nameserver.py
@@ -9,7 +9,7 @@ from netbox_dns.models import NameServer
 class NameServerFilter(TenancyFilterSet, NetBoxModelFilterSet):
     class Meta:
         model = NameServer
-        fields = ("id", "name", "tenant")
+        fields = ("id", "name", "tenant", "tag")
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox_dns/forms/nameserver.py
+++ b/netbox_dns/forms/nameserver.py
@@ -68,6 +68,7 @@ class NameServerImportForm(NetBoxModelImportForm):
             "name",
             "description",
             "tenant",
+            "tags",
         )
 
 

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -187,6 +187,7 @@ class RecordImportForm(NetBoxModelImportForm):
             "disable_ptr",
             "description",
             "tenant",
+            "tags",
         )
 
 

--- a/netbox_dns/forms/view.py
+++ b/netbox_dns/forms/view.py
@@ -53,7 +53,7 @@ class ViewImportForm(NetBoxModelImportForm):
 
     class Meta:
         model = View
-        fields = ("name", "description", "tenant")
+        fields = ("name", "description", "tenant", "tags")
 
 
 class ViewBulkEditForm(NetBoxModelBulkEditForm):

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -461,6 +461,7 @@ class ZoneImportForm(NetBoxModelImportForm):
             "tech_c",
             "billing_c",
             "tenant",
+            "tags",
         )
 
 

--- a/netbox_dns/tables/view.py
+++ b/netbox_dns/tables/view.py
@@ -1,6 +1,6 @@
 import django_tables2 as tables
 
-from netbox.tables import NetBoxTable
+from netbox.tables import NetBoxTable, TagColumn
 from tenancy.tables import TenancyColumnsMixin
 
 from netbox_dns.models import View
@@ -10,8 +10,9 @@ class ViewTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
         linkify=True,
     )
+    tags = TagColumn(url_name="plugins:netbox_dns:view_list")
 
     class Meta(NetBoxTable.Meta):
         model = View
-        fields = ("name", "description", "tenant", "tenant_group")
+        fields = ("name", "description", "tenant", "tenant_group", "tags")
         default_columns = ("name",)


### PR DESCRIPTION
fixes #110

Fixed a very, very old bug, back from the days of `netbox-dns` (and painstakingly ported forward for a while).

`Zone`, `NameServer`, `Record` and `View` allowed tags to be set from the very beginning, but tags have never been importable. This is fixed now.

While I was at it, I fixed some other tag-related quirks as well.