### PR TITLE
Experimental Feature: Related DNS records for IP Addresses without IPAM Coupling

### DIFF
--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -6,7 +6,7 @@ except ImportError:
     from extras.plugins.utils import get_plugin_config
 from extras.plugins import PluginTemplateExtension
 
-from netbox_dns.models import Record, Zone, View, NameServer
+from netbox_dns.models import Record, RecordTypeChoices, Zone, View, NameServer
 from netbox_dns.tables import RelatedRecordTable
 
 
@@ -22,6 +22,44 @@ class RelatedDNSRecords(PluginTemplateExtension):
             for address_record in address_records
             if address_record.ptr_record is not None
         ]
+
+        if address_records:
+            address_record_table = RelatedRecordTable(
+                data=address_records,
+            )
+        else:
+            address_record_table = None
+
+        if pointer_records:
+            pointer_record_table = RelatedRecordTable(
+                data=pointer_records,
+            )
+        else:
+            pointer_record_table = None
+
+        return self.render(
+            "netbox_dns/record/related.html",
+            extra_context={
+                "related_address_records": address_record_table,
+                "related_pointer_records": pointer_record_table,
+            },
+        )
+
+
+class IPRelatedDNSRecords(PluginTemplateExtension):
+    model = "ipam.ipaddress"
+
+    def right_page(self):
+        ip_address = self.context.get("object")
+
+        address_records = Record.objects.filter(
+            type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA),
+            ip_address=ip_address.address.ip,
+        )
+        pointer_records = Record.objects.filter(
+            type=RecordTypeChoices.PTR,
+            ip_address=ip_address.address.ip,
+        )
 
         if address_records:
             address_record_table = RelatedRecordTable(
@@ -83,3 +121,5 @@ class RelatedDNSObjects(PluginTemplateExtension):
 template_extensions = [RelatedDNSObjects]
 if get_plugin_config("netbox_dns", "feature_ipam_coupling"):
     template_extensions.append(RelatedDNSRecords)
+elif get_plugin_config("netbox_dns", "feature_ipam_dns_info"):
+    template_extensions.append(IPRelatedDNSRecords)

--- a/netbox_dns/templates/netbox_dns/record/related.html
+++ b/netbox_dns/templates/netbox_dns/record/related.html
@@ -2,9 +2,9 @@
 
 {% if perms.netbox_dns.view_record %}
 {% if related_address_records %}
-{% include 'inc/panel_table.html' with table=related_address_records heading='Related DNS Address Record' %}
+{% include 'inc/panel_table.html' with table=related_address_records heading='Related DNS Address Records' %}
 {% endif %}
 {% if related_pointer_records %}
-{% include 'inc/panel_table.html' with table=related_pointer_records heading='Related DNS Pointer Record' %}
+{% include 'inc/panel_table.html' with table=related_pointer_records heading='Related DNS Pointer Records' %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
This PR contains a feature that makes it possible to show related DNS address or pointer records for an `IPAddress` object.

Note that all DNS records that match the IP address will be displayed, whether they are actually related to that IP address or not. Records could be in different views or relate to the same IP address in a different VRF, which cannot be determined without the IPAM coupling feature.

The feature can be enabled using the `feature_ipam_dns_info` configuration flag in `configuration.py`.