### PR TITLE
Fixed migration dependency with NetBox < 3.6.0

### DIFF
--- a/netbox_dns/migrations/0026_domain_registration.py
+++ b/netbox_dns/migrations/0026_domain_registration.py
@@ -7,7 +7,7 @@ import utilities.json
 class Migration(migrations.Migration):
     dependencies = [
         ("netbox_dns", "0025_ipam_coupling_cf"),
-        ("extras", "0098_webhook_custom_field_data_webhook_tags"),
+        ("extras", "0092_delete_jobresult"),
     ]
 
     operations = [


### PR DESCRIPTION
A `makemigrations` run done after NetBox 3.6.0 broke compatibility with NetBox 3.5.x. Fixed that by referencing an older NetBox migration as a dependency.