### PR TITLE
Fix post_clean signal handler for ipam.IPAddress

### DIFF
--- a/netbox_dns/signals/ipam_coupling.py
+++ b/netbox_dns/signals/ipam_coupling.py
@@ -28,6 +28,9 @@ except ImportError:
 
 @receiver(post_clean, sender=IPAddress)
 def ip_address_check_permissions_save(instance, **kwargs):
+    if not instance.address:
+        return
+
     if not get_plugin_config("netbox_dns", "feature_ipam_coupling"):
         return
 


### PR DESCRIPTION
fixes #141

Before working with the data supplied by the `clean()` method of `ipam.IPAddress`, check if the data supplied is valid.