### PR TITLE
Make the IP address statuses considered active configurable

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -581,6 +581,26 @@ The IP address is now linked to the address record in the following ways:
 * When the DNS zone is renamed, the 'DNS Name' for the IP address is updated to reflect the zone's new name
 * When the DNS zone is deleted, the address record is deleted and the connection from the IP address object is cleared
 
+#### Record Status set by IPAM Coupling
+
+The status of the address record created for an IP address depends on the status of the IP address. By default, address records for IP addresses in the statuses 'Active', 'DHCP' and 'SLAAC' are set to 'Active', while the status of the address record will be 'Inactive' in all other cases.
+
+This mapping can be configured using the configuration variable `ipam_coupling_ip_active_status_list` in the plugin configuration. This variable holds an array of status names. The default setting for the status list is `None`, which is equivalent to
+
+```
+PLUGINS_CONFIG = {
+    'netbox_dns': {
+        ...
+        'ipam_coupling_ip_address_status_list': [
+            'active',
+            'dhcp',
+            'slaac',
+        ],
+        ...
+    },
+}
+```
+
 ### Additional Information for IP Addresses and DNS Records
 
 When a link between an IP address and a DNS address record is present, there are some additional panes in the IPAM IP address and NetBox DNS record view, as well as in the detail views for NetBox DNS managed records.

--- a/netbox_dns/utilities/ipam_coupling.py
+++ b/netbox_dns/utilities/ipam_coupling.py
@@ -3,6 +3,13 @@ from utilities.permissions import resolve_permission
 
 from netbox_dns.models import Record, RecordTypeChoices, RecordStatusChoices
 
+try:
+    # NetBox 3.5.0 - 3.5.7, 3.5.9+
+    from extras.plugins import get_plugin_config
+except ImportError:
+    # NetBox 3.5.8
+    from extras.plugins.utils import get_plugin_config
+
 
 class DNSPermissionDenied(Exception):
     pass
@@ -27,9 +34,19 @@ def address_record_type(ip_address):
 
 
 def address_record_status(ip_address):
+    ip_active_status_list = get_plugin_config(
+        "netbox_dns",
+        "ipam_coupling_ip_active_status_list",
+        (
+            IPAddressStatusChoices.STATUS_ACTIVE,
+            IPAddressStatusChoices.STATUS_DHCP,
+            IPAddressStatusChoices.STATUS_SLAAC,
+        ),
+    )
+
     return (
         RecordStatusChoices.STATUS_ACTIVE
-        if ip_address.status == IPAddressStatusChoices.STATUS_ACTIVE
+        if ip_address.status in ip_active_status_list
         else RecordStatusChoices.STATUS_INACTIVE
     )
 


### PR DESCRIPTION
fixes #144

This PR adds a new configuration variable `ipam_coupling_ip_active_status_list` that can be used to define the list of statuses for IP addresses that are considered active by the IPAM coupling feature.

Address records for active IP addresses will be created in 'Active' state, while those for IP addresses with other statuses will be created in 'Inactive' state. The new configuration option makes it possible to use unorthodox or custom values for the status of an IP address and still create active address records for it.

This feature was inspired by @bitcollector1 in #140.