### PR TITLE
Fix/display status for managed records

### DIFF
--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -112,11 +112,11 @@
                         <td><a href="{% url 'ipam:ipaddress' pk=object.ipam_ip_address.pk %}">{{ object.ipam_ip_address }}</td>
                     </tr>
                     {% endif %}
-                    {% if not object.managed %}
                     <tr>
                         <th scope="row">Status</th>
                         <td>{{ object.status }}</td>
                     </tr>
+                    {% if object.description %}
                     <tr>
                         <th scope="row">Description</th>
                         <td style="word-break:break-all;">{{ object.description }}</td>

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -114,7 +114,7 @@
                     {% endif %}
                     <tr>
                         <th scope="row">Status</th>
-                        <td>{{ object.status }}</td>
+                        <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                     </tr>
                     {% if object.description %}
                     <tr>

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -42,7 +42,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Status</th>
-                        <td>{{ object.status }}</td>
+                        <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                     </tr>
                     <tr>
                         <th scope="row">Nameservers</th>


### PR DESCRIPTION
fixes #145 

In addition, status for zones and records is now displayed as a badge, making it consistent with NetBox core.