### PR TITLE
Workaround for NestedZoneSerializer "active=None" issue

### DIFF
--- a/netbox_dns/api/nested_serializers.py
+++ b/netbox_dns/api/nested_serializers.py
@@ -22,6 +22,20 @@ class NestedViewSerializer(WritableNestedSerializer):
 # Zones
 #
 class NestedZoneSerializer(WritableNestedSerializer):
+    def to_representation(self, instance):
+        # +
+        # Workaround for the problem that the serializer does not return the
+        # annotation "active" when called with "many=False". See issue
+        # https://github.com/peteeckel/netbox-plugin-dns/issues/132
+        #
+        # TODO: Investigate root cause, probably in DRF.
+        # -
+        representation = super().to_representation(instance)
+        if representation.get("active") is None:
+            representation["active"] = instance.is_active
+
+        return representation
+
     url = serializers.HyperlinkedIdentityField(
         view_name="plugins-api:netbox_dns-api:zone-detail"
     )


### PR DESCRIPTION
For some reason yet unknown, `NestedZoneSerializer` does not return the `active` annotation when `many=False` is set. That affects zone serialization for records (`zone`) and zones (`rfc2317_parent_zone`), where `active` is always returned as `None`.

This workaround fixes the problem by overriding `to_representation()` for the serializer and explicitly setting `active`.

fixes #132