### PR TITLE
Fixed deleting RFC2317 zone with multiple records of the same name

### DIFF
--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -698,9 +698,13 @@ class Zone(NetBoxModel):
                 )
             ]
 
-            for ptr_record in ptr_records:
-                if ptr_record.rfc2317_cname_record is not None:
-                    ptr_record.rfc2317_cname_record.delete()
+            cname_records = {
+                ptr_record.rfc2317_cname_record
+                for ptr_record in ptr_records
+                if ptr_record.rfc2317_cname_record is not None
+            }
+            for cname_record in cname_records:
+                cname_record.delete()
 
             rfc2317_child_zones = [
                 child_zone.pk for child_zone in self.rfc2317_child_zones.all()


### PR DESCRIPTION
fixes #155

Compile a set of all CNAMEs to delete instead of looping over PTR records which results in duplicate attempts to delete the same CNAME.