### PR TITLE
Enforce object permissions on coupled DNS record

### DIFF
--- a/netbox_dns/signals/ipam_coupling.py
+++ b/netbox_dns/signals/ipam_coupling.py
@@ -1,4 +1,5 @@
 from django.dispatch import receiver
+from django.db import transaction
 from django.db.models.signals import pre_save, post_save, pre_delete
 from django.core.exceptions import ValidationError, PermissionDenied
 from rest_framework.exceptions import PermissionDenied as APIPermissionDenied
@@ -38,32 +39,42 @@ def ip_address_check_permissions_save(instance, **kwargs):
     if request is None:
         return
 
+    request.post_save_ops = []
+
     try:
-        if instance.id is None:
-            record = new_address_record(instance)
-            if record is not None:
-                record.full_clean()
-                check_permission(request, "netbox_dns.add_record", record)
-
-        else:
-            if not dns_changed(IPAddress.objects.get(pk=instance.id), instance):
-                return
-
-            record = get_address_record(instance)
-            if record is not None:
-                name, ttl, disable_ptr, zone_id = ipaddress_cf_data(instance)
-                if zone_id is not None:
-                    update_address_record(record, instance)
-                    record.full_clean()
-                    check_permission(request, "netbox_dns.change_record", record)
-                else:
-                    check_permission(request, "netbox_dns.delete_record", record)
-
-            else:
+        with transaction.atomic():
+            if instance.id is None:
                 record = new_address_record(instance)
                 if record is not None:
-                    record.full_clean()
+                    record.save()
                     check_permission(request, "netbox_dns.add_record", record)
+                    request.post_save_ops.append(("link_record", record))
+
+            else:
+                if not dns_changed(IPAddress.objects.get(pk=instance.id), instance):
+                    return
+
+                record = get_address_record(instance)
+                if record is not None:
+                    name, ttl, disable_ptr, zone_id = ipaddress_cf_data(instance)
+                    if zone_id is not None:
+                        # Check if current record is accessible
+                        check_permission(request, "netbox_dns.change_record", record)
+                        update_address_record(record, instance)
+                        record.save()
+                        # Check if modified record is accessible
+                        check_permission(request, "netbox_dns.change_record", record)
+                        request.post_save_ops.append(("link_record", record))
+                    else:
+                        check_permission(request, "netbox_dns.delete_record", record)
+                        record.delete()
+
+                else:
+                    record = new_address_record(instance)
+                    if record is not None:
+                        record.save()
+                        check_permission(request, "netbox_dns.add_record", record)
+                        request.post_save_ops.append(("link_record", record))
 
     except ValidationError as exc:
         if hasattr(exc, "error_dict"):
@@ -134,6 +145,13 @@ def ip_address_update_dns_information(instance, **kwargs):
 def ip_address_update_address_record(instance, **kwargs):
     if not get_plugin_config("netbox_dns", "feature_ipam_coupling"):
         return
+
+    request = current_request.get()
+    if hasattr(request, "post_save_ops"):
+        for op, record in request.post_save_ops:
+            if op == "link_record":
+                record.ipam_ip_address = instance
+                record.save()
 
     name, ttl, disable_ptr, zone_id = ipaddress_cf_data(instance)
 


### PR DESCRIPTION
In web UI or API context, the coupled record is immediately saved when the "post_clean" signal is called. All record creation/modification happen in a transaction, so that object permissions are enforced.

To complete the coupling, the "ipam_ip_address" field must be updated to reference the IP Address. It can't be done at this this point because the IP address is not created yet. It's actually done at the very end, when "post_save" is called. At record creation/modification time, we monkeypatch the "request" object to hold the necessary informations into a "post_save_ops" attribute.

On another note, the semantic of a permission for record modification was not well defined. Two permission checks are done:
- on the current record,
- on the modified record. The "test_modify_name_with_dns_object_permission" testcase takes care of this. Furthermore, two duplicated tests cases were removed.

This should have no impact in non-UI/non-API context, as permission checks are only done in "post_clean".