### PR TITLE
Do not enforce unique RRSet TTL for managed PTR records

### DIFF
--- a/netbox_dns/management/commands/cleanup_rrset_ttl.py
+++ b/netbox_dns/management/commands/cleanup_rrset_ttl.py
@@ -31,15 +31,17 @@ class Command(BaseCommand):
     def cleanup_rrset_ttl(self, **options):
         verbose = options.get("verbosity") > 1
 
-        ttl_records = Record.objects.filter(ttl__isnull=False).exclude(
-            type=RecordTypeChoices.SOA
+        ttl_records = (
+            Record.objects.filter(ttl__isnull=False)
+            .exclude(type=RecordTypeChoices.SOA)
+            .exclude(type=RecordTypeChoices.PTR, maanged=True)
         )
         for record in ttl_records:
             records = Record.objects.filter(
                 name=record.name,
                 zone=record.zone,
                 type=record.type,
-            )
+            ).exclude(type=RecordTypeChoices.PTR, maanged=True)
 
             if records.count() == 1:
                 if options.get("verbosity") > 2:


### PR DESCRIPTION
fixes #210

This PR results in managed `PTR` records being excluded from the check for and enforcement of unique TTLs across RRSets. For further discussion, see #209.
