### PR TITLE
Removed the ready() method

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -43,43 +43,6 @@ class DNSConfig(PluginConfig):
     }
     base_url = "netbox-dns"
 
-    def ready(self):
-        #
-        # Check if required custom fields exist for IPAM coupling
-        #
-        if get_plugin_config("netbox_dns", "feature_ipam_coupling"):
-            from extras.models import CustomField
-            from ipam.models import IPAddress
-            from django.contrib.contenttypes.models import ContentType
-
-            try:
-                objtype = ContentType.objects.get_for_model(IPAddress)
-                required_cf = (
-                    "ipaddress_dns_record_name",
-                    "ipaddress_dns_record_ttl",
-                    "ipaddress_dns_record_disable_ptr",
-                    "ipaddress_dns_zone_id",
-                )
-
-                if CustomField.objects.filter(
-                    name__in=required_cf, content_types=objtype
-                ).count() < len(required_cf):
-                    print(
-                        "WARNING: 'feature_ipam_coupling' is enabled, but the required"
-                        " custom fields for IPAM DNS coupling are missing. Please run"
-                        " the Django management command 'setup_coupling' to create the"
-                        " missing custom fields.",
-                        file=sys.stderr,
-                    )
-            except OperationalError as exc:
-                print(
-                    "WARNING: Unable to connect to PostgreSQL, cannot check custom fields"
-                    " for feature_ipam_coupling",
-                    file=sys.stderr,
-                )
-
-        super().ready()
-
 
 #
 # Initialize plugin config


### PR DESCRIPTION
The `ready()` method doesn't provide any real functionality except writing a warning to the log if the custom fields are missing. 

As it makes problems with later versions of NetBox and will be dropped with NetBox version 4.0 anyway, it's no problem to remove it now.

fixes #218 