### PR TITLE
Swap the order of name and zone in Record tables

### DIFF
--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -61,8 +61,8 @@ class RecordTable(RecordBaseTable):
         model = Record
         fields = (
             "pk",
-            "zone",
             "name",
+            "zone",
             "ttl",
             "type",
             "value",
@@ -77,8 +77,8 @@ class RecordTable(RecordBaseTable):
             "tenant_group",
         )
         default_columns = (
-            "zone",
             "name",
+            "zone",
             "ttl",
             "type",
             "value",
@@ -101,8 +101,8 @@ class ManagedRecordTable(RecordBaseTable):
     class Meta(NetBoxTable.Meta):
         model = Record
         fields = (
-            "zone",
             "name",
+            "zone",
             "ttl",
             "type",
             "value",
@@ -112,8 +112,8 @@ class ManagedRecordTable(RecordBaseTable):
             "active",
         )
         default_columns = (
-            "zone",
             "name",
+            "zone",
             "ttl",
             "type",
             "value",


### PR DESCRIPTION
At some point it looked like a good idea to list the zone first, then the record name.

While in theory this makes sense, it leads to people clicking on the zone name instead of the record name over and over again because the zone name comes first in the table rows. Time to end that confusion ... 