### PR TITLE
Added FQDN to global search

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -60,11 +60,19 @@ NetBox DNS requires some tables for its data models within the NetBox database. 
 
 ### Restarting NetBox
 Restart the WSGI service and the request queue worker to load the new plugin:
+
 ```
 systemctl restart netbox netbox-rq
 ```
-
 Now NetBox DNS should show up under "Plugins" at the bottom of the left-hand side of the NetBox web GUI.
+
+### Reindexing Global Search
+In order for existing NetBox DNS objects to appear in the global search after the initial installation or some upgrades of NetBox DNS, the search indices need to be rebuilt. This can be done with the command
+
+```
+/opt/netbox/netbox/manage.py reindex netbox_dns
+```
+This can be done at any time, especially when items that should show up in the global search do not.
 
 ## Object types
 Currently NetBox DNS can manage four different object types: Views, Name Servers, Zones, and Records.

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -758,7 +758,8 @@ class Record(NetBoxModel):
 class RecordIndex(SearchIndex):
     model = Record
     fields = (
-        ("name", 100),
+        ("fqdn", 100),
+        ("name", 120),
         ("value", 150),
         ("zone", 200),
         ("type", 200),


### PR DESCRIPTION
fixes #239

This PR (finally) adds the FQDN to the NetBox global search index.

The index for NetBox DNS must be rebuilt after this update. For this, run the management command
```bash
/opt/netbox/netbox/manage.py reindex netbox_dns
```
A restart is not necessary after re-indexing.