### PR TITLE
Run `super().clean()` in custom `clean()` methods

### DIFF
--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -53,7 +53,7 @@ class NameServer(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:netbox_dns:nameserver", kwargs={"pk": self.pk})
 
-    def clean(self):
+    def clean(self, *args, **kwargs):
         try:
             self.name = normalize_name(self.name)
         except NameFormatError as exc:
@@ -71,6 +71,8 @@ class NameServer(NetBoxModel):
                     "name": exc,
                 }
             ) from None
+
+        super().clean(*args, **kwargs)
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -699,6 +699,8 @@ class Record(NetBoxModel):
                     }
                 ) from None
 
+        super().clean(*args, **kwargs)
+
     def save(
         self,
         *args,


### PR DESCRIPTION
fixes #248

The `post_clean()` signal is a NetBox custom signal and not a Django standard signal, and it is explicitly triggered by running the `super().clean()` method in custom clean() methods.

The `clean()` methods for `Record` and `NameServer` did not call that method, so validators were not run.