### PR TITLE
Always display tenant for records if defined, not only for unmanaged records

### DIFF
--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -53,7 +53,7 @@
                         <td><a href="{% url 'plugins:netbox_dns:zone_records' pk=object.zone.pk %}">{{ object.zone }}</a></td>
                         {% endif %}
                     </tr>
-                    {% if not object.managed %}
+                    {% if object.tenant %}
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>


### PR DESCRIPTION
fixes #250 

To avoid cluttering the UI too much, the 'Tenant' field is not displayed if it is unpopulated.
