### PR TITLE
Added validation of SOA SERIAL changes

### DIFF
--- a/netbox_dns/tests/zone/test_auto_soa.py
+++ b/netbox_dns/tests/zone/test_auto_soa.py
@@ -105,7 +105,7 @@ class ZoneAutoSOATestCase(TestCase):
 
     def test_zone_soa_change_serial(self):
         zone = self.zone
-        serial = 42
+        serial = 2100000000
 
         zone.soa_serial_auto = False
         zone.soa_serial = serial


### PR DESCRIPTION
Do not allow SOA SERIAL values to decrease. "Decrease" in this context has a special meaning:

* SOA SERIAL numbers use integer arithmetics modulo 2**32
* The maximum increase step is 2**31-1. Anything above that is considered a decrease
* This allows, for instance, changing a SOA SERIAL from 4200000000 to 42, but not vice versa
* For details, see [RFC 2182, Section 7](https://datatracker.ietf.org/doc/html/rfc2182#section-7)