### PR TITLE
Improve Documentation

### DIFF
--- a/examples/ansible/code/synchronize_dns_zones.yaml
+++ b/examples/ansible/code/synchronize_dns_zones.yaml
@@ -27,7 +27,7 @@
                         | map(attribute='name') }}"
 
 #
-# Create view folder and remove obsolete files
+# Create view folder and remove obsolete folders
 #
     - name: Create view directory
       ansible.builtin.file:

--- a/examples/ansible/using_netbox_dns_with_ansible.md
+++ b/examples/ansible/using_netbox_dns_with_ansible.md
@@ -111,9 +111,19 @@ $TTL {{ zone.default_ttl }}
 {% endfor %}
 ```
 
-#### Ansible playbook for creating zone files
-To create all the files for use with BIND DNS, you can use the example in `synchronize_dns_zones.yml`.
-With this playbook Ansible reads lists of all views and active zones creates the zone files in a folder
-for BIND to read. Then the BIND service is restarted.
+### Generate All Views and Zones from NetBox Using Ansible
 
-At the moment the BIND configuration files for the tones zones also need to be entered manually.
+The example playbook `synchronize_dns_zones.yaml` can be used to generate all views, zones, and corresponding records from NetBox using Ansible. These zone files are compatible with Bind9. Required parameters include:
+
+- `netbox_url`: The URL of the NetBox instance, e.g., `https://netbox.example.com/`
+- `netbox_token`: previously generated token
+- `zone_file_path`: Folder for the zones on the bind server
+
+This Ansible playbook will create a directory for each view within the specified folder (`zone_file_path: '/path_to_your_zone_files/'`) and generate the corresponding zone files for each view within these directories.
+
+If views or zones are deleted in NetBox, they will also be removed from the directories. This deletion occurs after creating the legitimate folders and files to prevent a change event with each execution of the playbook. If changes are detected, the Bind9 service on the server will be restarted.
+
+The playbook `delete_dns_files.yaml` must be in the same directory as the `synchronize_dns_zones.yaml` playbook, or the path in the `include_task` must be adjusted accordingly.
+
+**CAUTION! Currently, the generated zones must be manually added to the `named.conf.local` file.**
+


### PR DESCRIPTION
Hello, as previously mentioned here is a pr to bring the documentation back in line with the Examples. I wasnt sure how to better explain what to do, because the tasks itself  are pretty self explanatory in my view. Maybe you got some suggetions?

I plan on implementing another playbook to generate the needed bind configurations from netbox. (mainly named.conf.local and named.conf.options for Master and Minions) When i got that worked out should do a pr or do you think thats out of scope for this Project? 