### PR TITLE
Avoid saving records when nothing has changed in their values

### DIFF
--- a/netbox_dns/mixins/__init__.py
+++ b/netbox_dns/mixins/__init__.py
@@ -1,0 +1,1 @@
+from .object_modification import *

--- a/netbox_dns/mixins/object_modification.py
+++ b/netbox_dns/mixins/object_modification.py
@@ -1,0 +1,26 @@
+from netbox.models import NetBoxModel
+
+
+class ObjectModificationMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not hasattr(self.__class__, "check_fields"):
+            self.__class__.check_fields = (
+                {field.name for field in self._meta.fields}
+                - {field.name for field in NetBoxModel._meta.fields}
+                - {"id"}
+            )
+
+    @property
+    def changed_fields(self):
+        if self.pk is None:
+            return None
+
+        saved = self.__class__.objects.get(pk=self.pk)
+
+        return {
+            field
+            for field in self.check_fields
+            if getattr(self, field) != getattr(saved, field)
+        }

--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -14,11 +14,12 @@ from netbox_dns.utilities import (
     NameFormatError,
 )
 from netbox_dns.validators import validate_fqdn
+from netbox_dns.mixins import ObjectModificationMixin
 
 from .record import Record, RecordTypeChoices
 
 
-class NameServer(NetBoxModel):
+class NameServer(ObjectModificationMixin, NetBoxModel):
     name = models.CharField(
         unique=True,
         max_length=255,

--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -80,14 +80,12 @@ class NameServer(ObjectModificationMixin, NetBoxModel):
     def save(self, *args, **kwargs):
         self.full_clean()
 
-        name_changed = (
-            self.pk is not None and self.name != NameServer.objects.get(pk=self.pk).name
-        )
+        changed_fields = self.changed_fields
 
         with transaction.atomic():
             super().save(*args, **kwargs)
 
-            if name_changed:
+            if changed_fields is not None and "name" in changed_fields:
                 soa_zones = self.zones_soa.all()
                 for soa_zone in soa_zones:
                     soa_zone.update_soa_record()

--- a/netbox_dns/models/view.py
+++ b/netbox_dns/models/view.py
@@ -7,8 +7,10 @@ from netbox.search import SearchIndex, register_search
 from netbox.context import current_request
 from utilities.exceptions import AbortRequest
 
+from netbox_dns.mixins import ObjectModificationMixin
 
-class View(NetBoxModel):
+
+class View(ObjectModificationMixin, NetBoxModel):
     name = models.CharField(
         unique=True,
         max_length=255,

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -35,6 +35,7 @@ from netbox_dns.validators import (
     validate_fqdn,
     validate_domain_name,
 )
+from netbox_dns.mixins import ObjectModificationMixin
 
 # +
 # This is a hack designed to break cyclic imports between View, Record and Zone
@@ -77,7 +78,7 @@ class ZoneStatusChoices(ChoiceSet):
     ]
 
 
-class Zone(NetBoxModel):
+class Zone(ObjectModificationMixin, NetBoxModel):
     ACTIVE_STATUS_LIST = (ZoneStatusChoices.STATUS_ACTIVE,)
 
     view = models.ForeignKey(

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -684,17 +684,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
     def save(self, *args, **kwargs):
         self.full_clean()
 
-        new_zone = self.pk is None
-        if not new_zone:
-            old_zone = Zone.objects.get(pk=self.pk)
-
-        name_changed = not new_zone and old_zone.name != self.name
-        view_changed = not new_zone and old_zone.view != self.view
-        status_changed = not new_zone and old_zone.status != self.status
-        rfc2317_changed = not new_zone and (
-            old_zone.rfc2317_prefix != self.rfc2317_prefix
-            or old_zone.rfc2317_parent_managed != self.rfc2317_parent_managed
-        )
+        changed_fields = self.changed_fields
 
         if self.soa_serial_auto:
             self.soa_serial = self.get_auto_serial()
@@ -702,7 +692,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
         super().save(*args, **kwargs)
 
         if (
-            new_zone or name_changed or view_changed or status_changed
+            changed_fields is None or {"name", "view", "status"} & changed_fields
         ) and self.is_reverse_zone:
             zones = Zone.objects.filter(
                 view=self.view,
@@ -734,11 +724,9 @@ class Zone(ObjectModificationMixin, NetBoxModel):
                     child_zone.update_rfc2317_parent_zone()
 
         if (
-            new_zone
-            or name_changed
-            or view_changed
-            or status_changed
-            or rfc2317_changed
+            changed_fields is None
+            or {"name", "view", "status", "rfc2317_prefix", "rfc2317_parent_managed"}
+            & changed_fields
         ) and self.is_rfc2317_zone:
             zones = Zone.objects.filter(
                 view=self.view,
@@ -764,7 +752,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
 
             self.update_rfc2317_parent_zone()
 
-        elif name_changed or view_changed or status_changed:
+        elif changed_fields is not None and {"name", "view", "status"} & changed_fields:
             for address_record in self.record_set.filter(
                 type__in=(record.RecordTypeChoices.A, record.RecordTypeChoices.AAAA)
             ):
@@ -773,7 +761,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
             # Fix name in IP Address when zone name is changed
             if (
                 get_plugin_config("netbox_dns", "feature_ipam_coupling")
-                and name_changed
+                and "name" in changed_fields
             ):
                 for ip in IPAddress.objects.filter(
                     custom_field_data__ipaddress_dns_zone_id=self.pk
@@ -781,7 +769,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
                     ip.dns_name = f'{ip.custom_field_data["ipaddress_dns_record_name"]}.{self.name}'
                     ip.save(update_fields=["dns_name"])
 
-        if name_changed:
+        if changed_fields is not None and "name" in changed_fields:
             for _record in self.record_set.all():
                 _record.save(
                     update_fields=["fqdn"],


### PR DESCRIPTION
fixes #278 

This PR implements a new functionality that helps determining whether anything has changed in a non-saved instance of an object. 

This functionality is then used to determine whether or not to save a record to the database when its `save()` method is called. In some cases, the `save()` method is used to perform actions that don't actually affect the object it is called for, and in these cases saving the object to the database is redundant and should be avoided.