### PR TITLE
Support for NetBox 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: "netbox-community/netbox"
           path: netbox
-          ref: master
+          ref: feature
 
       - name: install netbox_dns
         working-directory: netbox-plugin-dns

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -1,13 +1,13 @@
 from netbox.plugins import PluginConfig
 
-__version__ = "1.0.2"
+__version__ = "1.1.0-dev"
 
 
 class DNSConfig(PluginConfig):
     name = "netbox_dns"
     verbose_name = "NetBox DNS"
     description = "NetBox plugin for DNS data"
-    min_version = "4.0.0"
+    min_version = "4.1.0-dev"
     version = __version__
     author = "Peter Eckel"
     author_email = "pete@netbox-dns.org"

--- a/netbox_dns/tests/record/test_event_rules.py
+++ b/netbox_dns/tests/record/test_event_rules.py
@@ -6,13 +6,13 @@ from packaging.version import Version
 import django_rq
 from django.urls import reverse
 from django.test import RequestFactory
-from django.conf import settings
 from rest_framework import status
 
 from core.models import ObjectType
 from extras.models import EventRule, Tag, Webhook
 from extras.choices import EventRuleActionChoices, ObjectChangeActionChoices
 from extras.context_managers import event_tracking
+from utilities.release import load_release_data
 from utilities.testing import APITestCase
 
 from netbox_dns.models import NameServer, Zone, Record, RecordTypeChoices
@@ -91,7 +91,7 @@ class RecordEventRuleTest(APITestCase):
             zone.save()
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_create_record(self):

--- a/netbox_dns/tests/test_netbox_dns.py
+++ b/netbox_dns/tests/test_netbox_dns.py
@@ -7,7 +7,7 @@ from netbox_dns.tests.custom import APITestCase
 
 class NetBoxDNSVersionTestCase(SimpleTestCase):
     def test_version(self):
-        assert __version__ == "1.0.2"
+        assert __version__ == "1.1.0-dev"
 
 
 class AppTest(APITestCase):

--- a/netbox_dns/tests/zone/test_event_rules.py
+++ b/netbox_dns/tests/zone/test_event_rules.py
@@ -6,13 +6,13 @@ from packaging.version import Version
 import django_rq
 from django.urls import reverse
 from django.test import RequestFactory
-from django.conf import settings
 from rest_framework import status
 
 from core.models import ObjectType
 from extras.models import EventRule, Tag, Webhook
 from extras.choices import EventRuleActionChoices, ObjectChangeActionChoices
 from extras.context_managers import event_tracking
+from utilities.release import load_release_data
 from utilities.testing import APITestCase
 
 from netbox_dns.models import NameServer, Zone
@@ -80,7 +80,7 @@ class ZoneEventRuleTest(APITestCase):
         }
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_create_zone(self):
@@ -138,7 +138,7 @@ class ZoneEventRuleTest(APITestCase):
         self.assertEqual(job.kwargs["snapshots"]["postchange"]["soa_refresh"], 86400)
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_add_nameservers(self):
@@ -170,7 +170,7 @@ class ZoneEventRuleTest(APITestCase):
         )
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_remove_nameservers(self):
@@ -200,7 +200,7 @@ class ZoneEventRuleTest(APITestCase):
         self.assertEqual(len(job.kwargs["snapshots"]["postchange"]["nameservers"]), 0)
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_add_tags(self):
@@ -231,7 +231,7 @@ class ZoneEventRuleTest(APITestCase):
         )
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        Version(load_release_data().version) < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_remove_tags(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netbox-plugin-dns"
-version = "1.0.2"
+version = "1.1.0-dev"
 description = "NetBox DNS is a NetBox plugin for managing DNS data."
 authors = ["Peter Eckel <pete@netbox-dns.org>"]
 homepage = "https://github.com/peteeckel/netbox-plugin-dns"
@@ -11,7 +11,7 @@ packages = [{include = "netbox_dns"}]
 exclude = ["netbox_dns/tests/*"]
 keywords = ["netbox", "netbox-plugin", "dns"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable"
+    "Development Status :: 4 - Beta"
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This is a tracking PR for the implementation of NetBox 4.1 compatibility features. It will be updated with 4.1 related fixes and enhancements over the next few months.
* Replaced references to `settings.VERSION` with `load_release_data()` [(NetBox PR #16420)](https://github.com/netbox-community/netbox/pull/16420)