### PR TITLE
Made the plugin menu more configurable

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -30,6 +30,8 @@ class DNSConfig(PluginConfig):
         "enable_root_zones": False,
         "enforce_unique_records": True,
         "enforce_unique_rrset_ttl": True,
+        "menu_name": "NetBox DNS",
+        "top_level_menu": True,
     }
     base_url = "netbox-dns"
 

--- a/netbox_dns/navigation.py
+++ b/netbox_dns/navigation.py
@@ -1,4 +1,8 @@
 from netbox.plugins import PluginMenuButton, PluginMenuItem, PluginMenu
+from netbox.plugins.utils import get_plugin_config
+
+menu_name = get_plugin_config("netbox_dns", "menu_name")
+top_level_menu = get_plugin_config("netbox_dns", "top_level_menu")
 
 view_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:view_list",
@@ -126,26 +130,38 @@ contact_menu_item = PluginMenuItem(
     ),
 )
 
-menu = PluginMenu(
-    label="NetBox DNS",
-    groups=(
-        (
-            "DNS Configuration",
+
+if top_level_menu:
+    menu = PluginMenu(
+        label=menu_name,
+        groups=(
             (
-                view_menu_item,
-                zone_menu_item,
-                nameserver_menu_item,
-                record_menu_item,
-                managed_record_menu_item,
+                "DNS Configuration",
+                (
+                    view_menu_item,
+                    zone_menu_item,
+                    nameserver_menu_item,
+                    record_menu_item,
+                    managed_record_menu_item,
+                ),
+            ),
+            (
+                "Domain Registration",
+                (
+                    registrar_menu_item,
+                    contact_menu_item,
+                ),
             ),
         ),
-        (
-            "Domain Registration",
-            (
-                registrar_menu_item,
-                contact_menu_item,
-            ),
-        ),
-    ),
-    icon_class="mdi mdi-dns",
-)
+        icon_class="mdi mdi-dns",
+    )
+else:
+    menu_items = (
+        view_menu_item,
+        zone_menu_item,
+        nameserver_menu_item,
+        record_menu_item,
+        managed_record_menu_item,
+        registrar_menu_item,
+        contact_menu_item,
+    )


### PR DESCRIPTION
fixes #295
fixes #296 

This PR aims at making the NetBox DNS entry in the plugin menu more configurable.

1. Optionally register the NetBox DNS menu items under the 'Plugins' top level menu
2. Optionally rename the 'NetBox DNS' menu item if it is not under the 'Plugins' top level menu

Due to the way NetBox integrates plugins, option 1 results in losing section labels 'DNS Configuration', 'Domain Registration' as there is one hierarchy level less available for this. This results in less clarity in the UI.

Both options cannot be used together because NetBox uses the verbose name of the plugin to construct the plugin's section label in the 'Plugins' top level menu. There currently is no way to override this except for changing the plugin's `verbose_name` setting.

Option 1 can be enabled in the configuration by setting
```python
PLUGINS_CONFIG = {
    'netbox_dns': {
        'top_level_menu': False,
    }
}
```

Option 2 can be enabled in the configuration by setting
```python
PLUGINS_CONFIG = {
    'netbox_dns': {
        'menu_name': 'DNS',
    }
}
```

The default setting is to leave everything unchanged.