### PR TITLE
Provide an option to allow additional characters in zone labels

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -530,6 +530,7 @@ There are some special cases that need to be taken care of:
 To take care of these cases, there are three configuration variables for NetBox DNS that adjust the validation of record names:
 
 * `tolerate_underscores_in_labels` can be set to allow the use of undercores in host names. Underscores are normally only permitted in certain record types such as SRV, not in normal host names, but at least one operating system's DNS implementation does not follow the standard and allows this.
+* `tolerate_characters_in_zone_labels` is a string consisting of characters that are to be allowed in zone labels in addition to the standard characters. This can be used to allow zone names like `0/25.2.0.192.in-addr.arpa` from the RFC2317 examples. Allowing special characters can lead to unexpected results with zone provisioning tools and to zones not loadable by some or all DNS server implementations, so use this option with extreme caution.
 * `tolerate_leading_underscore_types` contains a list of RR types that allow an underscore as the first character in a label.
 * `tolerate_non_rfc1035_types` contains a list of record types that allow characters outside the set defined in RFC1035 to be used in RR names. Record types in this list are exempt from validation.
 
@@ -537,7 +538,8 @@ To take care of these cases, there are three configuration variables for NetBox 
 
 Variable                            | Factory Default
 --------                            | ---------------
-`tolerate_underscores_in_labels`    | False
+`tolerate_underscores_in_labels`    | `False`
+`tolerate_characters_in_zone_labels`| `''`
 `tolerate_leading_underscore_types` | `["TXT", "SRV"]`
 `tolerate_non_rfc1035_types`        | `[]`
 
@@ -548,6 +550,7 @@ PLUGINS_CONFIG = {
     'netbox_dns': {
         ...
         'tolerate_underscores_in_labels': True,
+        'tolerate_characters_in_zone_labels': "/",
         'tolerate_leading_underscore_types': ["TXT", "SRV", "CNAME"]
         'tolerate_non_rfc1035_types': ["X25"]
     },

--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -529,17 +529,17 @@ There are some special cases that need to be taken care of:
 
 To take care of these cases, there are three configuration variables for NetBox DNS that adjust the validation of record names:
 
-* `tolerate_underscores_in_hostnames` can be set to allow the use of undercores in host names. Underscores are normally only permitted in certain record types such as SRV, not in normal host names, but at least one operating system's DNS implementation does not follow the standard and allows this.
+* `tolerate_underscores_in_labels` can be set to allow the use of undercores in host names. Underscores are normally only permitted in certain record types such as SRV, not in normal host names, but at least one operating system's DNS implementation does not follow the standard and allows this.
 * `tolerate_leading_underscore_types` contains a list of RR types that allow an underscore as the first character in a label.
 * `tolerate_non_rfc1035_types` contains a list of record types that allow characters outside the set defined in RFC1035 to be used in RR names. Record types in this list are exempt from validation.
 
 #### <a name="validation_defaults"></a>Name validation default settings
 
-Variable                                 | Factory Default
---------                                 | ---------------
-`tolerate_underscores_in_hostnames `     | False
-`tolerate_leading_underscore_types `     | `["TXT", "SRV"]`
-`tolerate_non_rfc1035_types `            | `[]`
+Variable                            | Factory Default
+--------                            | ---------------
+`tolerate_underscores_in_labels`    | False
+`tolerate_leading_underscore_types` | `["TXT", "SRV"]`
+`tolerate_non_rfc1035_types`        | `[]`
 
 The settings can be set or overridden in the file `/opt/netbox/netbox/netbox/configuration.py` by defining new values in `PLUGINS_CONFIG` as follows:
 
@@ -547,7 +547,7 @@ The settings can be set or overridden in the file `/opt/netbox/netbox/netbox/con
 PLUGINS_CONFIG = {
     'netbox_dns': {
         ...
-        'tolerate_underscores_in_hostnames': True,
+        'tolerate_underscores_in_labels': True,
         'tolerate_leading_underscore_types': ["TXT", "SRV", "CNAME"]
         'tolerate_non_rfc1035_types': ["X25"]
     },

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -21,7 +21,9 @@ class DNSConfig(PluginConfig):
         "zone_soa_expire": 2419200,
         "zone_soa_minimum": 3600,
         "feature_ipam_coupling": False,
-        "tolerate_underscores_in_hostnames": False,
+        "tolerate_characters_in_zone_labels": "",
+        "tolerate_underscores_in_labels": False,
+        "tolerate_underscores_in_hostnames": False,  # Deprecated, will be removed in 1.2.0
         "tolerate_leading_underscore_types": [
             "TXT",
             "SRV",

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -22,7 +22,7 @@ from netbox_dns.utilities import (
 )
 from netbox_dns.validators import (
     validate_fqdn,
-    validate_extended_hostname,
+    validate_generic_name,
     validate_domain_name,
 )
 from netbox_dns.mixins import ObjectModificationMixin
@@ -494,7 +494,7 @@ class Record(ObjectModificationMixin, NetBoxModel):
             "netbox_dns", "tolerate_non_rfc1035_types", default=[]
         ):
             try:
-                validate_extended_hostname(
+                validate_generic_name(
                     self.name,
                     (
                         self.type
@@ -575,7 +575,7 @@ class Record(ObjectModificationMixin, NetBoxModel):
 
                 case RecordTypeChoices.NAPTR:
                     _validate_idn(rr.replacement)
-                    validate_extended_hostname(
+                    validate_generic_name(
                         rr.replacement.to_text(), always_tolerant=True
                     )
 

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -541,14 +541,19 @@ class Record(ObjectModificationMixin, NetBoxModel):
                     )
 
                 case (
-                    RecordTypeChoices.DNAME
-                    | RecordTypeChoices.NS
+                    RecordTypeChoices.NS
                     | RecordTypeChoices.HTTPS
                     | RecordTypeChoices.SRV
                     | RecordTypeChoices.SVCB
                 ):
                     _validate_idn(rr.target)
                     validate_domain_name(rr.target.to_text(), always_tolerant=True)
+
+                case RecordTypeChoices.DNAME:
+                    _validate_idn(rr.target)
+                    validate_domain_name(
+                        rr.target.to_text(), always_tolerant=True, zone_name=True
+                    )
 
                 case RecordTypeChoices.PTR | RecordTypeChoices.NSAP_PTR:
                     _validate_idn(rr.target)

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -610,7 +610,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
             ) from None
 
         try:
-            validate_domain_name(self.name)
+            validate_domain_name(self.name, zone_name=True)
         except ValidationError as exc:
             raise ValidationError(
                 {

--- a/netbox_dns/tests/nameserver/test_name_validation.py
+++ b/netbox_dns/tests/nameserver/test_name_validation.py
@@ -36,7 +36,7 @@ class NameServerNameValidationTestCase(TestCase):
                 NameServer.objects.create(name=name)
 
     @override_settings(
-        PLUGINS_CONFIG={"netbox_dns": {"tolerate_underscores_in_hostnames": True}}
+        PLUGINS_CONFIG={"netbox_dns": {"tolerate_underscores_in_labels": True}}
     )
     def test_name_validation_tolerant_ok(self):
         names = (

--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -116,7 +116,7 @@ class RecordNameValidationTestCase(TestCase):
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
                 "tolerate_leading_underscore_types": ["TXT", "SRV"],
                 "tolerate_non_rfc1035_types": [],
             }
@@ -136,7 +136,7 @@ class RecordNameValidationTestCase(TestCase):
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
                 "tolerate_leading_underscore_types": ["TXT", "SRV"],
                 "tolerate_non_rfc1035_types": [],
             }
@@ -154,7 +154,7 @@ class RecordNameValidationTestCase(TestCase):
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
                 "tolerate_leading_underscore_types": ["TXT", "SRV"],
                 "tolerate_non_rfc1035_types": [],
             }
@@ -182,7 +182,7 @@ class RecordNameValidationTestCase(TestCase):
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
                 "tolerate_leading_underscore_types": ["TXT", "SRV"],
                 "tolerate_non_rfc1035_types": [],
             }

--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -105,6 +105,7 @@ class RecordNameValidationTestCase(TestCase):
             {"name": "x" * 64 + f".{self.zones[1].name}", "zone": self.zones[1]},
             {"name": "xn--n", "zone": self.zones[0]},
             {"name": "xn--n.zone1.example.com.", "zone": self.zones[0]},
+            {"name": "na/me1.zone1.example.com.", "zone": self.zones[0]},
         )
 
         for record in records:
@@ -201,3 +202,30 @@ class RecordNameValidationTestCase(TestCase):
                 Record.objects.create(
                     name=record.get("name"), zone=record.get("zone"), **self.record_data
                 )
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                "tolerate_characters_in_zone_labels": "/",
+            }
+        }
+    )
+    def test_name_validation_allow_special_character_ok(self):
+        zone = self.zones[0]
+        zone.name = "zo/ne1.example.com"
+        zone.save()
+
+        record = Record.objects.create(name="name1", zone=zone, **self.record_data)
+
+        self.assertEqual(record.fqdn, "name1.zo/ne1.example.com.")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                "tolerate_characters_in_zone_labels": "/",
+            }
+        }
+    )
+    def test_name_validation_allow_special_character_failure(self):
+        with self.assertRaises(ValidationError):
+            Record.objects.create(name="na/me1", zone=self.zones[0], **self.record_data)

--- a/netbox_dns/tests/zone/test_name_validation.py
+++ b/netbox_dns/tests/zone/test_name_validation.py
@@ -52,6 +52,7 @@ class ZoneNameValidationTestCase(TestCase):
             + ".12345678" * 26
             + ".example.com.",  # 256 octets, trailing dot
             ".",  # root zone
+            "0/25.2.0.192.in-addr.arpa",  # RFC 2317 sample zone including "/"
         )
 
         for name in names:
@@ -111,3 +112,18 @@ class ZoneNameValidationTestCase(TestCase):
         for name in names:
             with self.assertRaises(ValidationError):
                 Zone.objects.create(name=name, **self.zone_data)
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_dns": {
+                **zone_defaults,
+                "tolerate_characters_in_zone_labels": "/",
+            }
+        }
+    )
+    def test_name_validation_allow_special_character_ok(self):
+        names = ("0/25.2.0.192.in-addr.arpa",)  # RFC 2317 sample zone including "/"
+
+        zone = Zone.objects.create(name="0/25.2.0.192.in-addr.arpa", **self.zone_data)
+
+        self.assertEqual(zone.name, "0/25.2.0.192.in-addr.arpa")

--- a/netbox_dns/tests/zone/test_name_validation.py
+++ b/netbox_dns/tests/zone/test_name_validation.py
@@ -74,7 +74,7 @@ class ZoneNameValidationTestCase(TestCase):
         PLUGINS_CONFIG={
             "netbox_dns": {
                 **zone_defaults,
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
             }
         }
     )
@@ -92,7 +92,7 @@ class ZoneNameValidationTestCase(TestCase):
         PLUGINS_CONFIG={
             "netbox_dns": {
                 **zone_defaults,
-                "tolerate_underscores_in_hostnames": True,
+                "tolerate_underscores_in_labels": True,
             }
         }
     )

--- a/netbox_dns/utilities/__init__.py
+++ b/netbox_dns/utilities/__init__.py
@@ -21,7 +21,7 @@ def arpa_to_prefix(arpa_name):
 
         try:
             return IPNetwork(f"{address}/{mask}")
-        except AddrFormatError:
+        except (AddrFormatError, ValueError):
             return None
 
     elif name.endswith("ip6.arpa"):

--- a/netbox_dns/validators/dns_name.py
+++ b/netbox_dns/validators/dns_name.py
@@ -52,7 +52,7 @@ def validate_fqdn(name, always_tolerant=False):
         raise ValidationError(f"{name} is not a valid fully qualified DNS host name")
 
 
-def validate_extended_hostname(
+def validate_generic_name(
     name, tolerate_leading_underscores=False, always_tolerant=False
 ):
     label, zone_label = _get_label(


### PR DESCRIPTION
fixes #299 

This PR adds a new configuration variable, `tolerate_characters_in_zone_labels`, that can be used to enhance the set of characters allowed in zone labels.

The rationale behind this is that [RFC2181, Section 11](https://datatracker.ietf.org/doc/html/rfc2181#section-11) generally allows arbitrary characters in labels, while most DNS server and resolver implementations are much more restrictive. As an example and the immediate reason for this PR,  [RFC2137](https://datatracker.ietf.org/doc/html/rfc2317) uses example zones that contain a slash `/` in their names, which normally isn't permitted by NetBox DNS.

Using slashes in zone names is generally not a very good idea at all, considering the fact that URLs might be constructed using zone names containing `/`, or DNS provisioning tools could use the zone name to create the file name of a zone file on disk with them, both leading to unexpected behaviour.

For this reason, the use of unusual characters was only provided as a configuration option that by default is turned off. **Use with extreme caution, you've been warned.**

### Deprecation Notice
This PR also renames the configuration variable `tolerate_underscores_in_hostnames` to `tolerate_underscores_in_labels`. This was done because the term 'hostname'  does not make too much sense in the context of DNS, and to clarify that the setting affects all labels of a host name. The old variable will still be supported until NetBox DNS 1.2.0, which will be released together with NetBox 4.2.0, i.e. presumably in Q2/2025. 