### PR TITLE
Miscellaneous code cleanup tasks

### DIFF
--- a/netbox_dns/tables/nameserver.py
+++ b/netbox_dns/tables/nameserver.py
@@ -20,7 +20,6 @@ class NameServerTable(TenancyColumnsMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = NameServer
         fields = (
-            "pk",
             "name",
             "description",
             "tags",
@@ -28,7 +27,6 @@ class NameServerTable(TenancyColumnsMixin, NetBoxTable):
             "tenant_group",
         )
         default_columns = (
-            "pk",
             "name",
             "tags",
         )

--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -44,7 +44,6 @@ class RecordBaseTable(TenancyColumnsMixin, NetBoxTable):
 
 
 class RecordTable(RecordBaseTable):
-    pk = ToggleColumn()
     status = ChoiceFieldColumn()
     disable_ptr = tables.BooleanColumn(
         verbose_name="Disable PTR",
@@ -60,7 +59,6 @@ class RecordTable(RecordBaseTable):
     class Meta(NetBoxTable.Meta):
         model = Record
         fields = (
-            "pk",
             "name",
             "zone",
             "ttl",

--- a/netbox_dns/tables/zone.py
+++ b/netbox_dns/tables/zone.py
@@ -55,7 +55,6 @@ class ZoneTable(TenancyColumnsMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Zone
         fields = (
-            "pk",
             "name",
             "view",
             "status",
@@ -78,7 +77,6 @@ class ZoneTable(TenancyColumnsMixin, NetBoxTable):
             "tenant_group",
         )
         default_columns = (
-            "pk",
             "name",
             "view",
             "status",

--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -119,9 +119,6 @@ class RelatedDNSObjects(PluginTemplateExtension):
 
 template_extensions = []
 
-if version.parse(settings.VERSION) < version.parse("3.7.0"):
-    template_extensions.append(RelatedDNSObjects)
-
 if get_plugin_config("netbox_dns", "feature_ipam_coupling"):
     template_extensions.append(RelatedDNSRecords)
 elif get_plugin_config("netbox_dns", "feature_ipam_dns_info"):


### PR DESCRIPTION
fixes #307 

* Removed a conditional that matches only on NetBox < 3.7, which is not supported
* Removed references to the `pk` column from all tables