### PR TITLE
Fixed serialisers for the `Zone` model

### DIFF
--- a/netbox_dns/api/serializers_/zone.py
+++ b/netbox_dns/api/serializers_/zone.py
@@ -58,24 +58,28 @@ class ZoneSerializer(NetBoxModelSerializer):
         help_text="The registrar the domain is registered with",
     )
     registrant = ContactSerializer(
+        nested=True,
         many=False,
         read_only=False,
         required=False,
         help_text="The owner of the domain",
     )
     admin_c = ContactSerializer(
+        nested=True,
         many=False,
         read_only=False,
         required=False,
         help_text="The administrative contact for the domain",
     )
     tech_c = ContactSerializer(
+        nested=True,
         many=False,
         read_only=False,
         required=False,
         help_text="The technical contact for the domain",
     )
     billing_c = ContactSerializer(
+        nested=True,
         many=False,
         read_only=False,
         required=False,

--- a/netbox_dns/tests/zone/test_api.py
+++ b/netbox_dns/tests/zone/test_api.py
@@ -1,7 +1,7 @@
 from utilities.testing import APIViewTestCases, create_tags
 
 from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
-from netbox_dns.models import View, Zone, NameServer
+from netbox_dns.models import View, Zone, NameServer, Registrar, Contact
 
 
 class ZoneAPITestCase(
@@ -46,11 +46,47 @@ class ZoneAPITestCase(
         )
         View.objects.bulk_create(views)
 
+        registrars = (
+            Registrar(name="Registrar 1"),
+            Registrar(name="Registrar 2"),
+        )
+        Registrar.objects.bulk_create(registrars)
+
+        contacts = (
+            Contact(contact_id="contact-1"),
+            Contact(contact_id="contact-2"),
+            Contact(contact_id="contact-3"),
+            Contact(contact_id="contact-4"),
+        )
+        Contact.objects.bulk_create(contacts)
+
         zones = (
-            Zone(name="zone1.example.com", **zone_data),
-            Zone(name="zone2.example.com", **zone_data),
-            Zone(name="zone3.example.com", **zone_data, view=views[0]),
-            Zone(name="zone4.example.com", **zone_data, view=views[1]),
+            Zone(
+                name="zone1.example.com",
+                **zone_data,
+                registrar=registrars[0],
+                registrant=contacts[0],
+                admin_c=contacts[1],
+                tech_c=contacts[2],
+                billing_c=contacts[3]
+            ),
+            Zone(name="zone2.example.com", **zone_data, registrar=registrars[0]),
+            Zone(
+                name="zone3.example.com",
+                **zone_data,
+                view=views[0],
+                registrar=registrars[0],
+                registrant=contacts[0],
+                admin_c=contacts[0],
+                tech_c=contacts[0],
+                billing_c=contacts[0]
+            ),
+            Zone(
+                name="zone4.example.com",
+                **zone_data,
+                view=views[1],
+                registrar=registrars[1]
+            ),
             Zone(name="zone5.example.com", **zone_data, view=views[2]),
         )
         for zone in zones:
@@ -64,6 +100,11 @@ class ZoneAPITestCase(
                 "status": "reserved",
                 **zone_data,
                 "soa_mname": nameserver.pk,
+                "registrar": registrars[0].pk,
+                "registrant": contacts[0].pk,
+                "admin_c": contacts[1].pk,
+                "tech_c": contacts[1].pk,
+                "billing_c": contacts[2].pk,
             },
             {
                 "name": "zone7.example.com",
@@ -76,6 +117,11 @@ class ZoneAPITestCase(
                 "status": "reserved",
                 **zone_data,
                 "soa_mname": nameserver.pk,
+                "registrar": registrars[0].pk,
+                "registrant": contacts[0].pk,
+                "admin_c": contacts[1].pk,
+                "tech_c": contacts[2].pk,
+                "billing_c": contacts[3].pk,
             },
             {
                 "name": "zone9.example.com",
@@ -99,4 +145,9 @@ class ZoneAPITestCase(
         cls.bulk_update_data = {
             "view": views[2].pk,
             "tags": [t.pk for t in tags],
+            "registrar": registrars[1].pk,
+            "registrant": contacts[3].pk,
+            "admin_c": contacts[2].pk,
+            "tech_c": contacts[1].pk,
+            "billing_c": contacts[0].pk,
         }


### PR DESCRIPTION
fixes #311

The serialisers for the `Zone` objects' `registrant`, `admin_c`, `tech_c` and `billing_c` attributes were missing the `nested=True` setting.