### PR TITLE
Separate models from choices

### DIFF
--- a/examples/custom-scripts/DNS_IPAM_Updater.py
+++ b/examples/custom-scripts/DNS_IPAM_Updater.py
@@ -3,10 +3,11 @@
 import dns
 from dns import name as dns_name
 
-from netbox_dns.models import Record, View, RecordTypeChoices, Zone
 from ipam.models import IPAddress, VRF
-
 from extras.scripts import Script, ObjectVar, BooleanVar
+
+from netbox_dns.models import Record, View, Zone
+from netbox_dns.choices import RecordTypeChoices
 
 name = "NetBox DNS IPAM Import/Export"
 

--- a/examples/custom-scripts/NetBox_DNS_Tenancy.py
+++ b/examples/custom-scripts/NetBox_DNS_Tenancy.py
@@ -3,7 +3,8 @@
 from extras.scripts import Script
 from ipam.models import IPAddress
 
-from netbox_dns.models import Record, RecordTypeChoices
+from netbox_dns.models import Record
+from netbox_dns.choices import RecordTypeChoices
 
 name = "NetBox DNS Tenancy Synchronizer"
 

--- a/netbox_dns/choices/__init__.py
+++ b/netbox_dns/choices/__init__.py
@@ -1,0 +1,2 @@
+from .record import *
+from .zone import *

--- a/netbox_dns/choices/record.py
+++ b/netbox_dns/choices/record.py
@@ -1,0 +1,42 @@
+from dns import rdatatype, rdataclass
+
+from utilities.choices import ChoiceSet
+
+
+def initialize_choice_names(cls):
+    for choice in cls.CHOICES:
+        setattr(cls, choice[0], choice[0])
+    return cls
+
+
+@initialize_choice_names
+class RecordTypeChoices(ChoiceSet):
+    CHOICES = [
+        (rdtype.name, rdtype.name)
+        for rdtype in sorted(rdatatype.RdataType, key=lambda a: a.name)
+        if not rdatatype.is_metatype(rdtype)
+    ]
+    SINGLETONS = [
+        rdtype.name for rdtype in rdatatype.RdataType if rdatatype.is_singleton(rdtype)
+    ]
+
+
+@initialize_choice_names
+class RecordClassChoices(ChoiceSet):
+    CHOICES = [
+        (rdclass.name, rdclass.name)
+        for rdclass in sorted(rdataclass.RdataClass)
+        if not rdataclass.is_metaclass(rdclass)
+    ]
+
+
+class RecordStatusChoices(ChoiceSet):
+    key = "Record.status"
+
+    STATUS_ACTIVE = "active"
+    STATUS_INACTIVE = "inactive"
+
+    CHOICES = [
+        (STATUS_ACTIVE, "Active", "blue"),
+        (STATUS_INACTIVE, "Inactive", "red"),
+    ]

--- a/netbox_dns/choices/zone.py
+++ b/netbox_dns/choices/zone.py
@@ -1,0 +1,17 @@
+from utilities.choices import ChoiceSet
+
+
+class ZoneStatusChoices(ChoiceSet):
+    key = "Zone.status"
+
+    STATUS_ACTIVE = "active"
+    STATUS_RESERVED = "reserved"
+    STATUS_DEPRECATED = "deprecated"
+    STATUS_PARKED = "parked"
+
+    CHOICES = [
+        (STATUS_ACTIVE, "Active", "blue"),
+        (STATUS_RESERVED, "Reserved", "cyan"),
+        (STATUS_DEPRECATED, "Deprecated", "red"),
+        (STATUS_PARKED, "Parked", "gray"),
+    ]

--- a/netbox_dns/filtersets/record.py
+++ b/netbox_dns/filtersets/record.py
@@ -9,7 +9,8 @@ from utilities.filters import MultiValueCharFilter
 
 from ipam.models import IPAddress
 
-from netbox_dns.models import View, Zone, Record, RecordTypeChoices, RecordStatusChoices
+from netbox_dns.models import View, Zone, Record
+from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
 
 
 class RecordFilterSet(TenancyFilterSet, NetBoxModelFilterSet):

--- a/netbox_dns/filtersets/zone.py
+++ b/netbox_dns/filtersets/zone.py
@@ -7,14 +7,8 @@ from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import MultiValueCharFilter
 
-from netbox_dns.models import (
-    View,
-    Zone,
-    ZoneStatusChoices,
-    Registrar,
-    Contact,
-    NameServer,
-)
+from netbox_dns.models import View, Zone, Registrar, Contact, NameServer
+from netbox_dns.choices import ZoneStatusChoices
 
 
 class ZoneFilterSet(TenancyFilterSet, NetBoxModelFilterSet):

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -20,7 +20,8 @@ from utilities.forms.rendering import FieldSet
 from tenancy.models import Tenant
 from tenancy.forms import TenancyForm, TenancyFilterForm
 
-from netbox_dns.models import View, Zone, Record, RecordTypeChoices, RecordStatusChoices
+from netbox_dns.models import View, Zone, Record
+from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode
 
 

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -26,11 +26,11 @@ from tenancy.forms import TenancyForm, TenancyFilterForm
 from netbox_dns.models import (
     View,
     Zone,
-    ZoneStatusChoices,
     NameServer,
     Registrar,
     Contact,
 )
+from netbox_dns.choices import ZoneStatusChoices
 from netbox_dns.utilities import name_to_unicode
 from netbox_dns.fields import RFC2317NetworkFormField
 from netbox_dns.validators import validate_ipv4, validate_prefix, validate_rfc2317

--- a/netbox_dns/management/commands/cleanup_database.py
+++ b/netbox_dns/management/commands/cleanup_database.py
@@ -2,12 +2,8 @@ from netaddr import IPAddress, IPNetwork, AddrFormatError
 
 from django.core.management.base import BaseCommand
 
-from netbox_dns.models import (
-    Zone,
-    ZoneStatusChoices,
-    Record,
-    RecordTypeChoices,
-)
+from netbox_dns.models import Zone, Record
+from netbox_dns.choices import ZoneStatusChoices, RecordTypeChoices
 
 
 def zone_rename_passive_status_to_parked(verbose=False):

--- a/netbox_dns/management/commands/cleanup_rrset_ttl.py
+++ b/netbox_dns/management/commands/cleanup_rrset_ttl.py
@@ -1,10 +1,8 @@
 from django.core.management.base import BaseCommand
 from django.db.models import Max, Min
 
-from netbox_dns.models import (
-    Record,
-    RecordTypeChoices,
-)
+from netbox_dns.models import Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class Command(BaseCommand):

--- a/netbox_dns/migrations/0001_squashed_netbox_dns_0_22.py
+++ b/netbox_dns/migrations/0001_squashed_netbox_dns_0_22.py
@@ -11,8 +11,7 @@ import taggit.managers
 import utilities.json
 from django.db import migrations, models
 
-
-from netbox_dns.models import RecordTypeChoices
+from netbox_dns.choices import RecordTypeChoices
 from netbox_dns.utilities import arpa_to_prefix
 
 

--- a/netbox_dns/migrations/0021_record_ip_address.py
+++ b/netbox_dns/migrations/0021_record_ip_address.py
@@ -5,7 +5,7 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 import netbox_dns.fields.address
-from netbox_dns.models import RecordTypeChoices
+from netbox_dns.choices import RecordTypeChoices
 from netbox_dns.utilities import arpa_to_prefix
 
 

--- a/netbox_dns/models/__init__.py
+++ b/netbox_dns/models/__init__.py
@@ -5,4 +5,9 @@ from .view import *
 from .contact import *
 from .registrar import *
 
+# +
+# Backwards compatibility fix, will be removed in version 1.1
+# -
+from netbox_dns.choices import *
+
 from netbox_dns.signals import ipam_coupling

--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -13,10 +13,11 @@ from netbox_dns.utilities import (
     normalize_name,
     NameFormatError,
 )
+from netbox_dns.choices import RecordTypeChoices
 from netbox_dns.validators import validate_fqdn
 from netbox_dns.mixins import ObjectModificationMixin
 
-from .record import Record, RecordTypeChoices
+from .record import Record
 
 
 class NameServer(ObjectModificationMixin, NetBoxModel):

--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -5,7 +5,8 @@ from django.conf import settings
 from netbox.plugins.utils import get_plugin_config
 from netbox.plugins import PluginTemplateExtension
 
-from netbox_dns.models import Record, RecordTypeChoices, Zone, View, NameServer
+from netbox_dns.models import Record, Zone, View, NameServer
+from netbox_dns.choices import RecordTypeChoices
 from netbox_dns.tables import RelatedRecordTable
 
 

--- a/netbox_dns/tests/ipam_coupling/test_records.py
+++ b/netbox_dns/tests/ipam_coupling/test_records.py
@@ -5,13 +5,8 @@ from django.core.exceptions import ValidationError
 from ipam.models import IPAddress
 from ipam.choices import IPAddressStatusChoices
 from netaddr import IPNetwork
-from netbox_dns.models import (
-    Record,
-    Zone,
-    NameServer,
-    RecordTypeChoices,
-    RecordStatusChoices,
-)
+from netbox_dns.models import Record, Zone, NameServer
+from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
 
 
 class IPAMCouplingRecordTestCase(TestCase):

--- a/netbox_dns/tests/record/test_api.py
+++ b/netbox_dns/tests/record/test_api.py
@@ -5,7 +5,8 @@ from rest_framework import status
 from utilities.testing import APIViewTestCases
 
 from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
-from netbox_dns.models import View, Zone, NameServer, Record, RecordTypeChoices
+from netbox_dns.models import View, Zone, NameServer, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordAPITestCase(

--- a/netbox_dns/tests/record/test_auto_ptr.py
+++ b/netbox_dns/tests/record/test_auto_ptr.py
@@ -3,7 +3,8 @@ import ipaddress
 from django.test import TestCase
 
 
-from netbox_dns.models import NameServer, Record, RecordTypeChoices, Zone
+from netbox_dns.models import NameServer, Record, Zone
+from netbox_dns.choices import RecordTypeChoices
 
 
 def reverse_name(address, reverse_zone):

--- a/netbox_dns/tests/record/test_enforce_unique.py
+++ b/netbox_dns/tests/record/test_enforce_unique.py
@@ -1,7 +1,8 @@
 from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 
-from netbox_dns.models import NameServer, Zone, Record, RecordTypeChoices
+from netbox_dns.models import NameServer, Zone, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordEnforceUniqueTestCase(TestCase):

--- a/netbox_dns/tests/record/test_event_rules.py
+++ b/netbox_dns/tests/record/test_event_rules.py
@@ -15,7 +15,8 @@ from extras.choices import EventRuleActionChoices, ObjectChangeActionChoices
 from extras.context_managers import event_tracking
 from utilities.testing import APITestCase
 
-from netbox_dns.models import NameServer, Zone, Record, RecordTypeChoices
+from netbox_dns.models import NameServer, Zone, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordEventRuleTest(APITestCase):

--- a/netbox_dns/tests/record/test_filtersets.py
+++ b/netbox_dns/tests/record/test_filtersets.py
@@ -3,13 +3,8 @@ from django.test import TestCase
 from tenancy.models import Tenant, TenantGroup
 from utilities.testing import ChangeLoggedFilterSetTests
 
-from netbox_dns.models import (
-    Zone,
-    ZoneStatusChoices,
-    NameServer,
-    Record,
-    RecordTypeChoices,
-)
+from netbox_dns.models import Zone, NameServer, Record
+from netbox_dns.choices import ZoneStatusChoices, RecordTypeChoices
 from netbox_dns.filtersets import RecordFilterSet
 
 

--- a/netbox_dns/tests/record/test_fqdn.py
+++ b/netbox_dns/tests/record/test_fqdn.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from netbox_dns.models import NameServer, Zone, Record, RecordTypeChoices
+from netbox_dns.models import NameServer, Zone, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordFQDNTestSet(TestCase):

--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -1,7 +1,8 @@
 from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 
-from netbox_dns.models import NameServer, Zone, Record, RecordTypeChoices
+from netbox_dns.models import NameServer, Zone, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordNameValidationTestCase(TestCase):

--- a/netbox_dns/tests/record/test_normalization.py
+++ b/netbox_dns/tests/record/test_normalization.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
-from netbox_dns.models import Zone, Record, RecordTypeChoices, NameServer
+from netbox_dns.models import Zone, Record, NameServer
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordNormalizationTestCase(TestCase):

--- a/netbox_dns/tests/record/test_uniqueness.py
+++ b/netbox_dns/tests/record/test_uniqueness.py
@@ -1,7 +1,8 @@
 from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 
-from netbox_dns.models import Zone, Record, RecordTypeChoices, NameServer
+from netbox_dns.models import Zone, Record, NameServer
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordUniquenessTestCase(TestCase):

--- a/netbox_dns/tests/record/test_validation.py
+++ b/netbox_dns/tests/record/test_validation.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
-from netbox_dns.models import Zone, Record, RecordTypeChoices, NameServer
+from netbox_dns.models import Zone, Record, NameServer
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RecordValidationTestCase(TestCase):

--- a/netbox_dns/tests/record/test_views.py
+++ b/netbox_dns/tests/record/test_views.py
@@ -1,14 +1,8 @@
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import (
-    View,
-    Zone,
-    NameServer,
-    Record,
-    RecordTypeChoices,
-    RecordStatusChoices,
-)
+from netbox_dns.models import View, Zone, NameServer, Record
+from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
 
 
 class RecordViewTestCase(

--- a/netbox_dns/tests/rfc2317/test_records.py
+++ b/netbox_dns/tests/rfc2317/test_records.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from netbox_dns.models import NameServer, View, Zone, Record, RecordTypeChoices
+from netbox_dns.models import NameServer, View, Zone, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 class RFC2317RecordTestCase(TestCase):

--- a/netbox_dns/tests/view/test_auto_ptr.py
+++ b/netbox_dns/tests/view/test_auto_ptr.py
@@ -3,7 +3,8 @@ import ipaddress
 from django.test import TestCase
 
 
-from netbox_dns.models import View, Zone, NameServer, Record, RecordTypeChoices
+from netbox_dns.models import View, Zone, NameServer, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 def reverse_name(address, reverse_zone):

--- a/netbox_dns/tests/view/test_zone.py
+++ b/netbox_dns/tests/view/test_zone.py
@@ -5,7 +5,8 @@ from django.db.utils import IntegrityError
 from django.core.exceptions import ValidationError
 
 
-from netbox_dns.models import View, Zone, NameServer, Record, RecordTypeChoices
+from netbox_dns.models import View, Zone, NameServer, Record
+from netbox_dns.choices import RecordTypeChoices
 
 
 def reverse_name(address, reverse_zone):

--- a/netbox_dns/tests/zone/test_auto_ns.py
+++ b/netbox_dns/tests/zone/test_auto_ns.py
@@ -3,7 +3,8 @@ from dns import rdata
 from django.test import TestCase
 from django.db.models import ProtectedError
 
-from netbox_dns.models import NameServer, Record, RecordTypeChoices, Zone
+from netbox_dns.models import NameServer, Record, Zone
+from netbox_dns.choices import RecordTypeChoices
 
 
 class ZoneAutoNSTestCase(TestCase):

--- a/netbox_dns/tests/zone/test_auto_soa.py
+++ b/netbox_dns/tests/zone/test_auto_soa.py
@@ -2,13 +2,8 @@ from dns import rdata
 
 from django.test import TestCase
 
-from netbox_dns.models import (
-    NameServer,
-    Record,
-    RecordClassChoices,
-    RecordTypeChoices,
-    Zone,
-)
+from netbox_dns.models import NameServer, Record, Zone
+from netbox_dns.choices import RecordClassChoices, RecordTypeChoices
 
 
 def parse_soa_value(soa):

--- a/netbox_dns/tests/zone/test_auto_soa_serial.py
+++ b/netbox_dns/tests/zone/test_auto_soa_serial.py
@@ -7,13 +7,8 @@ from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 from django.conf import settings
 
-from netbox_dns.models import (
-    NameServer,
-    Record,
-    RecordTypeChoices,
-    RecordClassChoices,
-    Zone,
-)
+from netbox_dns.models import NameServer, Record, Zone
+from netbox_dns.choices import RecordClassChoices, RecordTypeChoices
 
 
 def set_soa_serial_back(zone):

--- a/netbox_dns/tests/zone/test_filtersets.py
+++ b/netbox_dns/tests/zone/test_filtersets.py
@@ -3,14 +3,9 @@ from django.test import TestCase
 from tenancy.models import Tenant, TenantGroup
 from utilities.testing import ChangeLoggedFilterSetTests
 
-from netbox_dns.models import (
-    Zone,
-    ZoneStatusChoices,
-    View,
-    NameServer,
-    Registrar,
-    Contact,
-)
+from netbox_dns.models import Zone, View, NameServer, Registrar, Contact
+from netbox_dns.choices import ZoneStatusChoices
+
 from netbox_dns.filtersets import ZoneFilterSet
 
 

--- a/netbox_dns/tests/zone/test_views.py
+++ b/netbox_dns/tests/zone/test_views.py
@@ -1,7 +1,8 @@
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import NameServer, View, Zone, ZoneStatusChoices
+from netbox_dns.models import NameServer, View, Zone
+from netbox_dns.choices import ZoneStatusChoices
 
 
 class ZoneViewTestCase(

--- a/netbox_dns/utilities/ipam_coupling.py
+++ b/netbox_dns/utilities/ipam_coupling.py
@@ -1,7 +1,8 @@
 from ipam.choices import IPAddressStatusChoices
 from utilities.permissions import resolve_permission
 
-from netbox_dns.models import Record, RecordTypeChoices, RecordStatusChoices
+from netbox_dns.models import Record
+from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
 
 from netbox.plugins.utils import get_plugin_config
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -9,7 +9,8 @@ from netbox_dns.forms import (
     RecordForm,
     RecordBulkEditForm,
 )
-from netbox_dns.models import Record, RecordTypeChoices, Zone
+from netbox_dns.models import Record, Zone
+from netbox_dns.choices import RecordTypeChoices
 from netbox_dns.tables import RecordTable, ManagedRecordTable, RelatedRecordTable
 from netbox_dns.utilities import value_to_unicode
 


### PR DESCRIPTION
Previously, the `*Choices` definitions for the `Zone` and `Record` models were included in the `models` module. Moved them to their own module for clarity.

### Deprecation Notice
Custom scripts importing choices from `netbox_dns.models` need to be updated. 
```
from netbox_dns.models import ZoneStatusChoices
from netbox_dns.models import RecordStatusChoices
from netbox_dns.models import RecordClassChoices
from netbox_dns.models import RecordTypeChoices
```
must be changed to
```
from netbox_dns.choices import ZoneStatusChoices
from netbox_dns.choices import RecordStatusChoices
from netbox_dns.choices import RecordClassChoices
from netbox_dns.choices import RecordTypeChoices
```
respecively. 

Currently the old imports are still supported. This support will be removed in version 1.1.0.