### PR TITLE
Fixed tests for NetBox 4.0.8 (new Strawberry release)

### DIFF
--- a/netbox_dns/tests/custom.py
+++ b/netbox_dns/tests/custom.py
@@ -5,9 +5,9 @@ import strawberry_django
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
-from strawberry.type import StrawberryList, StrawberryOptional
-from strawberry.union import StrawberryUnion
-from strawberry.lazy_type import LazyType
+from strawberry.types.base import StrawberryList, StrawberryOptional
+from strawberry.types.union import StrawberryUnion
+from strawberry.types.lazy_type import LazyType
 
 from ipam.graphql.types import IPAddressFamilyType
 from utilities.testing.api import APITestCase as NetBoxAPITestCase


### PR DESCRIPTION
Due to changed paths in the Strawberry module, some tests for NetBox DNS failed.