### PR TITLE
`disable_ptr` must be a `BooleanField` in `RecordForm`

### DIFF
--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -60,7 +60,7 @@ class RecordForm(TenancyForm, NetBoxModelForm):
         label="Zone",
     )
 
-    disable_ptr = forms.NullBooleanField(
+    disable_ptr = forms.BooleanField(
         label="Disable PTR",
         required=False,
     )


### PR DESCRIPTION
fixes #337

Commit d4056422f introduced an error in the field type.