### PR TITLE
Check for changed custom fields in `ObjectModificationMixin`

### DIFF
--- a/netbox_dns/mixins/object_modification.py
+++ b/netbox_dns/mixins/object_modification.py
@@ -15,6 +15,8 @@ class ObjectModificationMixin:
                 - {"id"}
             )
 
+            self.__class__.check_fields.add("custom_field_data")
+
     @property
     def changed_fields(self):
         if self.pk is None:


### PR DESCRIPTION
fixes #341

Apparently `custom_field_data` is not a normal model field. This leads to it being ignored when the list of fields for the `clean_fields` function is first created for a model.

As a result, when only the custom field data for an object is changed, the change may not result in the data being saved.

The solution is to add it to the list of field to check explicitly.