### PR TITLE
Modified event rule tests so they work both with NetBox 4.0.x and 4.1.x

### DIFF
--- a/netbox_dns/tests/zone/test_event_rules.py
+++ b/netbox_dns/tests/zone/test_event_rules.py
@@ -6,13 +6,24 @@ from packaging.version import Version
 import django_rq
 from django.urls import reverse
 from django.test import RequestFactory
-from django.conf import settings
 from rest_framework import status
 
 from core.models import ObjectType
 from extras.models import EventRule, Tag, Webhook
 from extras.choices import EventRuleActionChoices
-from extras.context_managers import event_tracking
+
+# Backward compatibility for NetBox 4.0.x
+try:
+    from netbox.context_managers import event_tracking
+    from utilities.release import load_release_data
+    from core.events import OBJECT_CREATED, OBJECT_UPDATED
+
+    NETBOX_VERSION = Version(load_release_data().version)
+except ImportError:
+    from extras.context_managers import event_tracking
+    from django.conf import settings
+
+    NETBOX_VERSION = Version(settings.VERSION)
 from utilities.testing import APITestCase
 
 from netbox_dns.models import NameServer, Zone
@@ -40,17 +51,29 @@ class ZoneEventRuleTest(APITestCase):
         )
         Webhook.objects.bulk_create(webhooks)
 
+        # Backward compatibility for NetBox 4.0.x
+        CREATE_OBJECT_SELECTOR = (
+            {"event_types": [OBJECT_CREATED]}
+            if NETBOX_VERSION >= Version("4.1.0")
+            else {"type_create": "True"}
+        )
+        UPDATE_OBJECT_SELECTOR = (
+            {"event_types": [OBJECT_UPDATED]}
+            if NETBOX_VERSION >= Version("4.1.0")
+            else {"type_update": "True"}
+        )
+
         event_rules = (
             EventRule(
                 name="Zone Create",
-                type_create=True,
+                **CREATE_OBJECT_SELECTOR,
                 action_type=EventRuleActionChoices.WEBHOOK,
                 action_object_type=webhook_type,
                 action_object_id=webhooks[0].id,
             ),
             EventRule(
                 name="Zone Update",
-                type_update=True,
+                **UPDATE_OBJECT_SELECTOR,
                 action_type=EventRuleActionChoices.WEBHOOK,
                 action_object_type=webhook_type,
                 action_object_id=webhooks[0].id,
@@ -80,7 +103,7 @@ class ZoneEventRuleTest(APITestCase):
         }
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        NETBOX_VERSION < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_create_zone(self):
@@ -138,7 +161,7 @@ class ZoneEventRuleTest(APITestCase):
         self.assertEqual(job.kwargs["snapshots"]["postchange"]["soa_refresh"], 86400)
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        NETBOX_VERSION < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_add_nameservers(self):
@@ -170,7 +193,7 @@ class ZoneEventRuleTest(APITestCase):
         )
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        NETBOX_VERSION < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_remove_nameservers(self):
@@ -200,7 +223,7 @@ class ZoneEventRuleTest(APITestCase):
         self.assertEqual(len(job.kwargs["snapshots"]["postchange"]["nameservers"]), 0)
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        NETBOX_VERSION < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_add_tags(self):
@@ -231,7 +254,7 @@ class ZoneEventRuleTest(APITestCase):
         )
 
     @skipIf(
-        Version(settings.VERSION) < Version(MIN_VERSION),
+        NETBOX_VERSION < Version(MIN_VERSION),
         f"Event rule processing is broken in NetBox < {MIN_VERSION}",
     )
     def test_update_zone_remove_tags(self):


### PR DESCRIPTION
In NetBox 4.1, some input paths and object attributes related to event hooks are changed, and the NetBox version is no longer accessible via `settings.VERSION` but via `utilities.release.load_release_data()`.

As these are (so far) the only places where NetBox 4.1 is incompatible to NetBox 4.0 it should be possible to support the 1.0.x release train of NetBox DNS, which still has IPAM Coupling instead of IPAM AutoDNS, on NetBox 4.1.x This provides a smoother migration path for users relying on IPAM Coupling.

At the same time, NetBox DNS 1.0.x will also be compatible with NetBox 4.0.x, which provides a migration path to IPAM AutoDNS without having to migrate to NetBox 4.1.

tl;dr: No more version dependencies between NetBox 4.x and NetBox DNS 1.x :-)