### PR TITLE
Enabled searching for records by FQDN in quick search

### DIFF
--- a/netbox_dns/filtersets/record.py
+++ b/netbox_dns/filtersets/record.py
@@ -121,7 +121,7 @@ class RecordFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         if not value.strip():
             return queryset
         qs_filter = (
-            Q(name__icontains=value)
+            Q(fqdn__icontains=value)
             | Q(value__icontains=value)
             | Q(zone__name__icontains=value)
         )


### PR DESCRIPTION
Until now, it has only been possible to search for the record name in quick search (global search had the FQDN for a while).