### PR TITLE
Fixed validation for RNAMEs containing a backslash

### DIFF
--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -34,6 +34,7 @@ from netbox_dns.utilities import (
 )
 from netbox_dns.validators import (
     validate_fqdn,
+    validate_rname,
     validate_domain_name,
 )
 from netbox_dns.mixins import ObjectModificationMixin
@@ -618,7 +619,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
             raise ValidationError("soa_rname not set and no default value defined")
         try:
             dns_name.from_text(self.soa_rname, origin=dns_name.root)
-            validate_fqdn(self.soa_rname)
+            validate_rname(self.soa_rname)
         except (DNSException, ValidationError) as exc:
             raise ValidationError(
                 {

--- a/netbox_dns/tests/zone/test_rname_validation.py
+++ b/netbox_dns/tests/zone/test_rname_validation.py
@@ -13,6 +13,8 @@ class ZoneRNameValidationTestCase(TestCase):
         rnames = (
             "hostmaster.example.com",
             "hostmaster.example.com.",
+            r"host\.master.example.com",
+            r"host\.master.example.com.",
         )
 
         for index, rname in enumerate(rnames):
@@ -27,6 +29,7 @@ class ZoneRNameValidationTestCase(TestCase):
         rnames = (
             "hostmaster",  # Not an FQDN
             "hostmaster@example.com",  # E-Mail address not converted to FQDN
+            r"host\.master.example",  # Too few zone labels after mailbox name
         )
 
         for index, rname in enumerate(rnames):

--- a/netbox_dns/validators/dns_name.py
+++ b/netbox_dns/validators/dns_name.py
@@ -7,6 +7,7 @@ from netbox.plugins.utils import get_plugin_config
 
 __all__ = (
     "validate_fqdn",
+    "validate_rname",
     "validate_generic_name",
     "validate_domain_name",
 )
@@ -55,6 +56,14 @@ def validate_fqdn(name, always_tolerant=False):
 
     if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
         raise ValidationError(f"{name} is not a valid fully qualified DNS host name")
+
+
+def validate_rname(name, always_tolerant=False):
+    label, zone_label = _get_label(always_tolerant=always_tolerant)
+    regex = rf"^(\*|{label})(\\\.{label})*(\.{zone_label}){{2,}}\.?$"
+
+    if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
+        raise ValidationError(f"{name} is not a valid RNAME")
 
 
 def validate_generic_name(


### PR DESCRIPTION
fixes #355

Allow for escaped dots in an RNAME before the zone part.