### PR TITLE
Fixed the FQDN column name

### DIFF
--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -25,10 +25,10 @@ class RecordBaseTable(TenancyColumnsMixin, NetBoxTable):
     )
     type = tables.Column()
     name = tables.Column(
-        verbose_name="FQDN",
         linkify=True,
     )
     fqdn = tables.Column(
+        verbose_name="FQDN",
         linkify=True,
     )
     value = tables.TemplateColumn(


### PR DESCRIPTION
Fixed #358

The last PR botched the column name for the `name` column. Noticed this too late :-(