### PR TITLE
Removed redundant field declarations in tables

### DIFF
--- a/netbox_dns/tables/contact.py
+++ b/netbox_dns/tables/contact.py
@@ -19,7 +19,6 @@ class ContactTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Contact
         fields = (
-            "contact_id",
             "name",
             "description",
             "organization",

--- a/netbox_dns/tables/nameserver.py
+++ b/netbox_dns/tables/nameserver.py
@@ -22,13 +22,7 @@ class NameServerTable(TenancyColumnsMixin, NetBoxTable):
 
     class Meta(NetBoxTable.Meta):
         model = NameServer
-        fields = (
-            "name",
-            "description",
-            "tags",
-            "tenant",
-            "tenant_group",
-        )
+        fields = ("description",)
         default_columns = (
             "name",
             "tags",

--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -73,22 +73,8 @@ class RecordTable(RecordBaseTable):
     class Meta(NetBoxTable.Meta):
         model = Record
         fields = (
-            "name",
-            "zone",
-            "fqdn",
-            "view",
-            "ttl",
-            "type",
-            "value",
-            "unicode_value",
             "status",
-            "disable_ptr",
-            "ptr_record",
-            "tags",
-            "active",
             "description",
-            "tenant",
-            "tenant_group",
         )
         default_columns = (
             "name",
@@ -114,19 +100,6 @@ class ManagedRecordTable(RecordBaseTable):
 
     class Meta(NetBoxTable.Meta):
         model = Record
-        fields = (
-            "name",
-            "zone",
-            "fqdn",
-            "view",
-            "ttl",
-            "type",
-            "value",
-            "unicode_value",
-            "address_record",
-            "ipam_ip_address",
-            "active",
-        )
         default_columns = (
             "name",
             "zone",
@@ -142,13 +115,6 @@ class RelatedRecordTable(RecordBaseTable):
 
     class Meta(NetBoxTable.Meta):
         model = Record
-        fields = (
-            "name",
-            "zone",
-            "type",
-            "value",
-            "unicode_value",
-        )
         default_columns = (
             "name",
             "zone",

--- a/netbox_dns/tables/record_template.py
+++ b/netbox_dns/tables/record_template.py
@@ -43,18 +43,8 @@ class RecordTemplateTable(TenancyColumnsMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = RecordTemplate
         fields = (
-            "name",
-            "record_name",
-            "ttl",
-            "type",
-            "value",
-            "unicode_value",
             "status",
-            "disable_ptr",
-            "tags",
             "description",
-            "tenant",
-            "tenant_group",
         )
         default_columns = (
             "name",
@@ -72,14 +62,7 @@ class RecordTemplateDisplayTable(RecordTemplateTable):
     class Meta(NetBoxTable.Meta):
         model = RecordTemplate
         fields = (
-            "name",
-            "record_name",
-            "ttl",
-            "type",
-            "value",
-            "unicode_value",
             "status",
-            "disable_ptr",
             "description",
         )
         default_columns = (

--- a/netbox_dns/tables/registrar.py
+++ b/netbox_dns/tables/registrar.py
@@ -19,13 +19,11 @@ class RegistrarTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Registrar
         fields = (
-            "name",
             "description",
             "iana_id",
             "referral_url",
             "whois_server",
             "abuse_email",
             "abuse_phone",
-            "tags",
         )
         default_columns = ("name", "iana_id", "referral_url")

--- a/netbox_dns/tables/view.py
+++ b/netbox_dns/tables/view.py
@@ -20,12 +20,5 @@ class ViewTable(TenancyColumnsMixin, NetBoxTable):
 
     class Meta(NetBoxTable.Meta):
         model = View
-        fields = (
-            "name",
-            "default_view",
-            "description",
-            "tenant",
-            "tenant_group",
-            "tags",
-        )
+        fields = ("description",)
         default_columns = ("name", "default_view")

--- a/netbox_dns/tables/zone.py
+++ b/netbox_dns/tables/zone.py
@@ -58,26 +58,11 @@ class ZoneTable(TenancyColumnsMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Zone
         fields = (
-            "name",
-            "view",
-            "status",
             "description",
-            "tags",
-            "default_ttl",
-            "soa_mname",
             "soa_rname",
             "soa_serial",
-            "rfc2317_prefix",
             "rfc2317_parent_managed",
-            "rfc2317_parent_zone",
-            "registrar",
             "registry_domain_id",
-            "registrant",
-            "admin_c",
-            "tech_c",
-            "billing_c",
-            "tenant",
-            "tenant_group",
         )
         default_columns = (
             "name",

--- a/netbox_dns/tables/zone_template.py
+++ b/netbox_dns/tables/zone_template.py
@@ -37,18 +37,7 @@ class ZoneTemplateTable(TenancyColumnsMixin, NetBoxTable):
 
     class Meta(NetBoxTable.Meta):
         model = ZoneTemplate
-        fields = (
-            "name",
-            "description",
-            "tags",
-            "registrar",
-            "registrant",
-            "admin_c",
-            "tech_c",
-            "billing_c",
-            "tenant",
-            "tenant_group",
-        )
+        fields = ("description",)
         default_columns = (
             "name",
             "tags",
@@ -60,10 +49,7 @@ class ZoneTemplateDisplayTable(ZoneTemplateTable):
 
     class Meta(NetBoxTable.Meta):
         model = ZoneTemplate
-        fields = (
-            "name",
-            "description",
-        )
+        fields = ("description",)
         default_columns = (
             "name",
             "description",


### PR DESCRIPTION
Many fields in tables that are declared explicitly were also listed in the `fields` array. This is redundant and should be avoided.