### PR TITLE
Fixed multiple REST API issues

### DIFF
--- a/netbox_dns/api/nested_serializers.py
+++ b/netbox_dns/api/nested_serializers.py
@@ -59,6 +59,22 @@ class NestedZoneSerializer(WritableNestedSerializer):
         ]
 
 
+class NestedZoneTemplateSerializer(WritableNestedSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_dns-api:zonetemplate-detail"
+    )
+
+    class Meta:
+        model = ZoneTemplate
+        fields = (
+            "id",
+            "url",
+            "name",
+            "display",
+            "description",
+        )
+
+
 class NestedRecordSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="plugins-api:netbox_dns-api:record-detail"
@@ -86,6 +102,7 @@ class NestedRecordSerializer(WritableNestedSerializer):
             "status",
             "ttl",
             "zone",
+            "managed",
             "active",
         ]
 
@@ -107,21 +124,5 @@ class NestedRecordTemplateSerializer(WritableNestedSerializer):
             "value",
             "status",
             "ttl",
-            "description",
-        )
-
-
-class NestedZoneTemplateSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name="plugins-api:netbox_dns-api:zonetemplate-detail"
-    )
-
-    class Meta:
-        model = ZoneTemplate
-        fields = (
-            "id",
-            "url",
-            "name",
-            "display",
             "description",
         )

--- a/netbox_dns/api/serializers_/record.py
+++ b/netbox_dns/api/serializers_/record.py
@@ -87,5 +87,6 @@ class RecordSerializer(NetBoxModelSerializer):
             "status",
             "ttl",
             "description",
+            "managed",
             "active",
         )

--- a/netbox_dns/tests/nameserver/test_api.py
+++ b/netbox_dns/tests/nameserver/test_api.py
@@ -1,7 +1,12 @@
+from django.urls import reverse
+from rest_framework import status
+
 from utilities.testing import APIViewTestCases
+from core.models import ObjectType
+from users.models import ObjectPermission
 
 from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
-from netbox_dns.models import NameServer
+from netbox_dns.models import NameServer, Zone
 
 
 class NameServerAPITestCase(
@@ -19,9 +24,9 @@ class NameServerAPITestCase(
     brief_fields = ["description", "display", "id", "name", "url"]
 
     create_data = [
-        {"name": "ns1.example.com"},
-        {"name": "ns2.example.com"},
-        {"name": "ns3.example.com"},
+        {"name": "ns4.example.com"},
+        {"name": "ns5.example.com"},
+        {"name": "ns6.example.com"},
     ]
 
     bulk_update_data = {
@@ -30,9 +35,191 @@ class NameServerAPITestCase(
 
     @classmethod
     def setUpTestData(cls):
-        nameservers = (
-            NameServer(name="ns4.example.com"),
-            NameServer(name="ns5.example.com"),
-            NameServer(name="ns6.example.com"),
+        cls.nameservers = (
+            NameServer(name="ns1.example.com"),
+            NameServer(name="ns2.example.com"),
+            NameServer(name="ns3.example.com"),
         )
-        NameServer.objects.bulk_create(nameservers)
+        NameServer.objects.bulk_create(cls.nameservers)
+
+        zone_data = {
+            "soa_mname": NameServer.objects.create(name="ns0.example.com"),
+            "soa_rname": "hostmaster.example.com",
+        }
+        cls.zones = (
+            Zone(name="zone1.example.com", **zone_data),
+            Zone(name="zone2.example.com", **zone_data),
+            Zone(name="zone3.example.com", **zone_data),
+            Zone(name="zone4.example.com", **zone_data),
+        )
+
+    def test_zones_per_nameserver_with_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones:
+            zone.save()
+        for zone in self.zones[0:3]:
+            zone.nameservers.set(self.nameservers)
+
+        self.add_permissions(
+            "netbox_dns.view_nameserver",
+            "netbox_dns.view_zone",
+        )
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-zones", kwargs={"pk": nameserver.pk}
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 3)
+        for zone in self.zones[0:3]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        self.assertFalse(
+            self.zones[3].pk
+            in [response_zone.get("id") for response_zone in response_zones]
+        )
+
+    def test_zones_per_nameserver_without_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones:
+            zone.save()
+        for zone in self.zones[0:3]:
+            zone.nameservers.set(self.nameservers)
+
+        self.add_permissions("netbox_dns.view_nameserver")
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-zones", kwargs={"pk": nameserver.pk}
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 0)
+
+    def test_zones_per_nameserver_with_constrained_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones:
+            zone.save()
+        for zone in self.zones[0:3]:
+            zone.nameservers.set(self.nameservers)
+
+        self.add_permissions("netbox_dns.view_nameserver")
+        object_permission = ObjectPermission(
+            name="View specific zones",
+            actions=["view"],
+            constraints={"name__in": [zone.name for zone in self.zones[0:2]]},
+        )
+        object_permission.save()
+        object_permission.object_types.add(ObjectType.objects.get_for_model(Zone))
+        object_permission.users.add(self.user)
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-zones", kwargs={"pk": nameserver.pk}
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 2)
+        for zone in self.zones[0:2]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        for zone in self.zones[2:4]:
+            self.assertFalse(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+
+    def test_soa_zones_per_nameserver_with_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones[0:3]:
+            zone.soa_mname = nameserver
+            zone.save()
+        self.zones[3].save()
+
+        self.add_permissions(
+            "netbox_dns.view_nameserver",
+            "netbox_dns.view_zone",
+        )
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-soa-zones",
+            kwargs={"pk": nameserver.pk},
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 3)
+        for zone in self.zones[0:3]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        self.assertFalse(
+            self.zones[3].pk
+            in [response_zone.get("id") for response_zone in response_zones]
+        )
+
+    def test_soa_zones_per_nameserver_without_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones[0:3]:
+            zone.soa_mname = nameserver
+            zone.save()
+        self.zones[3].save()
+
+        self.add_permissions("netbox_dns.view_nameserver")
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-soa-zones",
+            kwargs={"pk": nameserver.pk},
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 0)
+
+    def test_soa_zones_per_nameserver_with_constrained_permission(self):
+        nameserver = self.nameservers[0]
+        for zone in self.zones[0:3]:
+            zone.soa_mname = nameserver
+            zone.save()
+        self.zones[3].save()
+
+        self.add_permissions("netbox_dns.view_nameserver")
+        object_permission = ObjectPermission(
+            name="View specific zones",
+            actions=["view"],
+            constraints={"name__in": [zone.name for zone in self.zones[0:2]]},
+        )
+        object_permission.save()
+        object_permission.object_types.add(ObjectType.objects.get_for_model(Zone))
+        object_permission.users.add(self.user)
+
+        url = reverse(
+            "plugins-api:netbox_dns-api:nameserver-soa-zones",
+            kwargs={"pk": nameserver.pk},
+        )
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 2)
+        for zone in self.zones[0:2]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        for zone in self.zones[2:4]:
+            self.assertFalse(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )

--- a/netbox_dns/tests/record/test_api.py
+++ b/netbox_dns/tests/record/test_api.py
@@ -26,6 +26,7 @@ class RecordAPITestCase(
         "display",
         "fqdn",
         "id",
+        "managed",
         "name",
         "status",
         "ttl",

--- a/netbox_dns/tests/view/test_api.py
+++ b/netbox_dns/tests/view/test_api.py
@@ -1,10 +1,13 @@
 from django.test import override_settings
+from django.urls import reverse
 from rest_framework import status
 
+from core.models import ObjectType
+from users.models import ObjectPermission
 from utilities.testing import APIViewTestCases
 
 from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
-from netbox_dns.models import View
+from netbox_dns.models import View, NameServer, Zone
 
 
 class ViewAPITestCase(
@@ -34,8 +37,34 @@ class ViewAPITestCase(
     def _get_queryset(self):
         return self.model.objects.filter(default_view=False)
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.views = (
+            View(name="test1"),
+            View(name="test2"),
+            View(name="test3"),
+        )
+        View.objects.bulk_create(cls.views)
+
+        zone_data = {
+            "soa_mname": NameServer.objects.create(name="ns1.example.com"),
+            "soa_rname": "hostmaster.example.com",
+        }
+        cls.zones = (
+            Zone(name="zone1.example.com", **zone_data),
+            Zone(name="zone2.example.com", **zone_data),
+            Zone(name="zone3.example.com", **zone_data),
+            Zone(name="zone4.example.com", **zone_data),
+        )
+        for zone in cls.zones:
+            zone.save()
+
     @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
     def test_list_objects_anonymous(self):
+        # +
+        # The standard test of the NetBox test suite fails because of the
+        # default view. Override to exempt it from test.
+        # -
         url = f"{self._get_list_url()}?default_view=false"
 
         response = self.client.get(url, **self.header)
@@ -44,9 +73,12 @@ class ViewAPITestCase(
         self.assertEqual(len(response.data["results"]), self._get_queryset().count())
 
     def test_list_objects_brief(self):
-        self.add_permissions(
-            f"{self.model._meta.app_label}.view_{self.model._meta.model_name}"
-        )
+        # +
+        # The standard test of the NetBox test suite fails because of the
+        # default view. Override to exempt it from test.
+        # -
+        self.add_permissions("netbox_dns.view_view")
+
         url = f"{self._get_list_url()}?brief=1&default_view=false"
 
         response = self.client.get(url, **self.header)
@@ -54,11 +86,77 @@ class ViewAPITestCase(
         self.assertEqual(len(response.data["results"]), self._get_queryset().count())
         self.assertEqual(sorted(response.data["results"][0]), self.brief_fields)
 
-    @classmethod
-    def setUpTestData(cls):
-        views = (
-            View(name="test1"),
-            View(name="test2"),
-            View(name="test3"),
+    def test_zones_per_view_with_permission(self):
+        view = self.views[0]
+        for zone in self.zones[0:3]:
+            zone.view = view
+            zone.save()
+
+        self.add_permissions(
+            "netbox_dns.view_view",
+            "netbox_dns.view_zone",
         )
-        View.objects.bulk_create(views)
+
+        url = reverse("plugins-api:netbox_dns-api:view-zones", kwargs={"pk": view.pk})
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 3)
+        for zone in self.zones[0:3]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        self.assertFalse(
+            self.zones[3].pk
+            in [response_zone.get("id") for response_zone in response_zones]
+        )
+
+    def test_zones_per_view_without_permission(self):
+        view = self.views[0]
+        for zone in self.zones[0:3]:
+            zone.view = view
+            zone.save()
+
+        self.add_permissions("netbox_dns.view_view")
+
+        url = reverse("plugins-api:netbox_dns-api:view-zones", kwargs={"pk": view.pk})
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 0)
+
+    def test_zones_per_view_with_constrained_permission(self):
+        view = self.views[0]
+        for zone in self.zones[0:3]:
+            zone.view = view
+            zone.save()
+
+        self.add_permissions("netbox_dns.view_view")
+        object_permission = ObjectPermission(
+            name="View specific zones",
+            actions=["view"],
+            constraints={"name__in": [zone.name for zone in self.zones[0:2]]},
+        )
+        object_permission.save()
+        object_permission.object_types.add(ObjectType.objects.get_for_model(Zone))
+        object_permission.users.add(self.user)
+
+        url = reverse("plugins-api:netbox_dns-api:view-zones", kwargs={"pk": view.pk})
+        response = self.client.get(url, **self.header)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_zones = response.json()
+        self.assertEqual(len(response_zones), 2)
+        for zone in self.zones[0:2]:
+            self.assertTrue(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )
+        for zone in self.zones[2:4]:
+            self.assertFalse(
+                zone.pk in [response_zone.get("id") for response_zone in response_zones]
+            )


### PR DESCRIPTION
fixes #364 

1. Implemented tests (note to self: This should always be the first thing)
2. Replaced `/api/plugins/netbox-dns/views/{view-id}/views/` with `/api/plugins/netbox-dns/views/{view-id}/zones/`
3. Implemented `/api/plugins/netbox-dns/nameservers/{nameserver-id}/soa-zones/`
4. Removed `/api/plugins/netbox-dns/zones/{zone-id}/nameservers/`
5. Modified all endpoints to respect object restrictions (model/object level permissions)
6. Improved the implementation by using related object sets instead of separate queries
7. Replaced the full serializers for the results by the nested variants
8. Added `managed` to `brief_fields` for `Record`