### PR TITLE
Check against decrease by soa_serial_auto only if it gets enabled

### DIFF
--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -642,7 +642,7 @@ class Zone(ObjectModificationMixin, NetBoxModel):
             old_zone = Zone.objects.get(pk=self.pk)
             if not self.soa_serial_auto:
                 self.check_soa_serial_increment(old_zone.soa_serial, self.soa_serial)
-            else:
+            elif not old_zone.soa_serial_auto:
                 try:
                     self.check_soa_serial_increment(
                         old_zone.soa_serial, self.get_auto_serial()


### PR DESCRIPTION
fixes #368

One of the problems that aggravate the occurrence of spurious test failures is that the test for a decrease in the serial is conducted excessively often, instead of only when `soa_serial_auto` has not actually been disabled before the `save()` is executed.

This PR changes that behaviour, which is not really causing problems except for the excessive checks. It is hoped to reduce the occurrence of testing errors drastically.