### PR TITLE
Ability to add contacts to zones and records.

### DIFF
--- a/examples/contacts/README.md
+++ b/examples/contacts/README.md
@@ -1,0 +1,19 @@
+# Assigning Contacts to Records and Zones.
+
+You must have already created:
+
+- The actual contact you wish to assign to the record/zone.
+- a contact role.  It's suggested that roles are different for records vs. zones.
+- The dns record/zone already exists.
+
+The ansible playbook `assign-contacts.yaml` contains a sample task to update netbox using the URI mechanism.
+It uses the netbox `query` plugin to determine the correct rest call.
+
+## To see the assignments.
+
+Visit either contact assigned, or use the Contact Assignments search page.
+
+## Web interface
+
+At this time, there is no web interface to add contacts on the Records or Zones pages.
+

--- a/examples/contacts/assign-contacts.yaml
+++ b/examples/contacts/assign-contacts.yaml
@@ -1,0 +1,77 @@
+#
+# This ansible example task does not do:
+#  Any lookup of the contact ID's.
+#  Any lookup of the object ID to be linked to the contact.
+#
+# That exercise is left to you.
+#
+# You must have a working ansible netbox collection installed.
+# You must also have set in your environment the NETBOX_API url
+# and the NETBOX_TOKEN values.
+#
+# Simply run as `ansible-playbook ./assign-contacts`
+#
+---
+
+- name: assign contacts to objects.
+  hosts:
+    - localhost
+
+  gather_facts: false
+
+  vars:
+    cid:
+      nobody@gmail.com: 243
+
+    assignments:
+      - contact:
+          email: nobody@gmail.com
+        role:
+          slug: zone-admin
+        object_type: netbox_dns.zone
+        object_id: 1
+      - contact:
+          email: nobody@gmail.com
+        role:
+          slug: dns-record
+        object_type: netbox_dns.record
+        object_id: 1459
+
+  pre_tasks:
+    - name: get netbox url/token from 1password
+      ansible.builtin.set_fact:
+        netbox_url: "{{ lookup('env', 'NETBOX_API') }}"
+        netbox_token: "{{ lookup('env', 'NETBOX_TOKEN') }}"
+      run_once: true
+      no_log: true
+
+  tasks:
+    - name: Contact assignment test.
+      ansible.builtin.uri:
+        url: "{{ uri_url }}"
+        method: "{{ uri_method }}"
+        headers:
+          Authorization: "Token {{ netbox_token }}"
+        body_format: json
+        body:
+          contact:
+            email: "{{ item.contact.email }}"
+          role:
+            slug: "{{ item.role.slug }}"
+          object_type: "{{ item.object_type }}"
+          object_id: "{{ item.object_id }}"
+        status_code:
+          - 200
+          - 201
+      loop: "{{ assignments }}"
+      vars:
+        q_filter: "object_id={{ item.object_id }} object_type={{ item.object_type }} contact_id={{ cid[item.contact.email] }}"
+        q: "{{ query('netbox.netbox.nb_lookup',
+            'contact-assignments',
+            api_endpoint=netbox_url,
+            api_filter=q_filter,
+            raw_data=true,
+            token=netbox_token) }}"
+        c_id: "{{ q | map(attribute='id') | first | default(0) }}"
+        uri_method: "{% if c_id | int > 0 %}PATCH{% else %}POST{% endif %}"
+        uri_url: "{{ netbox_url }}/api/tenancy/contact-assignments/{% if c_id | int > 0 %}{{ c_id }}/{% endif %}"

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -9,6 +9,7 @@ from django.db.models import Q, ExpressionWrapper, BooleanField, Min
 from django.urls import reverse
 
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from netbox.search import SearchIndex, register_search
 from netbox.plugins.utils import get_plugin_config
 from utilities.querysets import RestrictedQuerySet
@@ -61,8 +62,7 @@ class RecordManager(models.Manager.from_queryset(RestrictedQuerySet)):
             )
         )
 
-
-class Record(ObjectModificationMixin, NetBoxModel):
+class Record(ContactsMixin, ObjectModificationMixin, NetBoxModel):
     ACTIVE_STATUS_LIST = (RecordStatusChoices.STATUS_ACTIVE,)
 
     unique_ptr_qs = Q(

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -19,10 +19,12 @@ from django.dispatch import receiver
 from django.conf import settings
 
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from netbox.search import SearchIndex, register_search
 from netbox.plugins.utils import get_plugin_config
 from utilities.querysets import RestrictedQuerySet
 from ipam.models import IPAddress
+
 
 from netbox_dns.choices import RecordClassChoices, RecordTypeChoices, ZoneStatusChoices
 from netbox_dns.fields import NetworkField, RFC2317NetworkField
@@ -67,7 +69,7 @@ class ZoneManager(models.Manager.from_queryset(RestrictedQuerySet)):
         )
 
 
-class Zone(ObjectModificationMixin, NetBoxModel):
+class Zone(ContactsMixin, ObjectModificationMixin, NetBoxModel):
     ACTIVE_STATUS_LIST = (ZoneStatusChoices.STATUS_ACTIVE,)
 
     def __init__(self, *args, **kwargs):

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
-from tenants.views.generic import ObjectContactsView
+from tenancy.views.generic import ObjectContactsView
 
 from netbox_dns.models import Record
 from netbox_dns.views import (

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from tenants.views.generic import ObjectContactsView
 
 from netbox_dns.models import Record
 from netbox_dns.views import (

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -44,6 +44,6 @@ record_urlpatterns = [
         "records/<int:pk>/contacts/",
         RecordContactView.as_view(),
         name="record_contacts",
-        kwargs={"contact": Record},
+        kwargs={"contacts": Record},
     ),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
-from tenancy.views.generic import ObjectContactsView
+from tenancy.views import ObjectContactsView
 
 from netbox_dns.models import Record
 from netbox_dns.views import (

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
-from tenancy.views import ObjectContactsView
+from tenancy.views import ObjectContactsView, ContactListView
 
 from netbox_dns.models import Record
 from netbox_dns.views import (
@@ -41,7 +41,7 @@ record_urlpatterns = [
     ),
     path(
         "records/<int:pk>/contacts/",
-        ObjectContactsView.as_view(),
+        ContactListView.as_view(),
         name="record_contacts",
         kwargs={"model": Record},
     ),

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -44,6 +44,6 @@ record_urlpatterns = [
         "records/<int:pk>/contacts/",
         RecordContactView.as_view(),
         name="record_contacts",
-        kwargs={"model": Record},
+        kwargs={"record": Record},
     ),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -12,7 +12,7 @@ from netbox_dns.views import (
     RecordBulkImportView,
     RecordBulkEditView,
     RecordBulkDeleteView,
-    RecrodContactsView,
+    RecordContactView,
     ManagedRecordListView,
 )
 

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -42,7 +42,7 @@ record_urlpatterns = [
     ),
     path(
         "records/<int:pk>/contacts/",
-        RecordContactsView.as_view(),
+        RecordContactView.as_view(),
         name="record_contacts",
         kwargs={"model": Record},
     ),

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -44,6 +44,6 @@ record_urlpatterns = [
         "records/<int:pk>/contacts/",
         RecordContactView.as_view(),
         name="record_contacts",
-        kwargs={"contacts": Record},
+        kwargs={"contact": Record},
     ),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -38,4 +38,10 @@ record_urlpatterns = [
     path(
         "managedrecords/", ManagedRecordListView.as_view(), name="managed_record_list"
     ),
+    path(
+        "records/<int:pk>/contacts/",
+        ObjectContactsView.as_view(),
+        name="record_contacts",
+        kwargs={"model": Record},
+    ),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -44,6 +44,6 @@ record_urlpatterns = [
         "records/<int:pk>/contacts/",
         RecordContactView.as_view(),
         name="record_contacts",
-        kwargs={"record": Record},
+        kwargs={"contact": Record},
     ),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -12,6 +12,7 @@ from netbox_dns.views import (
     RecordBulkImportView,
     RecordBulkEditView,
     RecordBulkDeleteView,
+    RecrodContactsView,
     ManagedRecordListView,
 )
 
@@ -41,7 +42,7 @@ record_urlpatterns = [
     ),
     path(
         "records/<int:pk>/contacts/",
-        ContactListView.as_view(),
+        RecordContactsView.as_view(),
         name="record_contacts",
         kwargs={"model": Record},
     ),

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -162,5 +162,5 @@ class RecordBulkDeleteView(generic.BulkDeleteView):
 
 @register_model_view(Record, 'contacts')
 class RecordContactsView(ObjectContactsView):
-    queryset = Recrod.objects.all()
+    queryset = Record.objects.all()
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -50,7 +50,7 @@ class ManagedRecordListView(generic.ObjectListView):
     template_name = "netbox_dns/record/managed.html"
 
 @register_model_view(Record)
-class RecordView(GetRelatedModelMixin, generic.ObjectView):
+class RecordView(GetRelatedModelsMixin, generic.ObjectView):
     queryset = Record.objects.all().prefetch_related("zone", "ptr_record")
 
     def get_value_records(self, instance):

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -161,7 +161,7 @@ class RecordBulkDeleteView(generic.BulkDeleteView):
     queryset = Record.objects.filter(managed=False)
     table = RecordTable
 
-@register_model_view(Record, 'contacts')
+@register_model_view(Record, 'contact')
 class RecordContactView(ObjectContactsView):
     queryset = Record.objects.all()
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -27,6 +27,7 @@ __all__ = (
     "RecordBulkImportView",
     "RecordBulkEditView",
     "RecordBulkDeleteView",
+    "RecordContactView",
 )
 
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -161,6 +161,6 @@ class RecordBulkDeleteView(generic.BulkDeleteView):
     table = RecordTable
 
 @register_model_view(Record, 'contacts')
-class RecordContactsView(ObjectContactsView):
+class RecordContactView(ObjectContactsView):
     queryset = Record.objects.all()
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -50,7 +50,7 @@ class ManagedRecordListView(generic.ObjectListView):
     template_name = "netbox_dns/record/managed.html"
 
 @register_model_view(Record)
-class RecordView(GetRelatedModelMixins, generic.ObjectView):
+class RecordView(GetRelatedModelMixin, generic.ObjectView):
     queryset = Record.objects.all().prefetch_related("zone", "ptr_record")
 
     def get_value_records(self, instance):

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -1,6 +1,9 @@
 from dns import name as dns_name
 
 from netbox.views import generic
+from tenancy.views import ObjectContactsView
+from utilities.views import GetRelatedModelsMixin, ViewTab, register_model_view
+
 
 from netbox_dns.filtersets import RecordFilterSet
 from netbox_dns.forms import (
@@ -46,7 +49,7 @@ class ManagedRecordListView(generic.ObjectListView):
     actions = {"export": {"view"}}
     template_name = "netbox_dns/record/managed.html"
 
-
+@register_model_view(Record)
 class RecordView(generic.ObjectView):
     queryset = Record.objects.all().prefetch_related("zone", "ptr_record")
 
@@ -122,7 +125,7 @@ class RecordView(generic.ObjectView):
 
         return context
 
-
+@register_model_view(Record, 'edit')
 class RecordEditView(generic.ObjectEditView):
     queryset = Record.objects.filter(managed=False).prefetch_related(
         "zone", "ptr_record"
@@ -131,6 +134,7 @@ class RecordEditView(generic.ObjectEditView):
     default_return_url = "plugins:netbox_dns:record_list"
 
 
+@register_model_view(Record, 'delete')
 class RecordDeleteView(generic.ObjectDeleteView):
     queryset = Record.objects.filter(managed=False)
     default_return_url = "plugins:netbox_dns:record_list"
@@ -155,3 +159,8 @@ class RecordBulkEditView(generic.BulkEditView):
 class RecordBulkDeleteView(generic.BulkDeleteView):
     queryset = Record.objects.filter(managed=False)
     table = RecordTable
+
+@register_model_view(Record, 'contacts')
+class RecordContactsView(ObjectContactsView):
+    queryset = Recrod.objects.all()
+

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -50,7 +50,7 @@ class ManagedRecordListView(generic.ObjectListView):
     template_name = "netbox_dns/record/managed.html"
 
 @register_model_view(Record)
-class RecordView(generic.ObjectView):
+class RecordView(GetRelatedModelMixins, generic.ObjectView):
     queryset = Record.objects.all().prefetch_related("zone", "ptr_record")
 
     def get_value_records(self, instance):


### PR DESCRIPTION
This adds the ability to assign contacts to Zones and DNS Records.

A sample Ansible task to do the assignment is included.

I didn't create any tests, since I haven't had the time to do so..

Currently the netbox web interfaces for Records/Zones doesn't show the contacts - I kept getting either nothing or errors.

https://github.com/netbox-community/netbox/pull/16231 was the reference for this.
