### PR TITLE
Added the feature to add Contacts to Zone, Record, View and NameServer

### DIFF
--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
+from netbox.models.features import ContactsMixin
 
 from netbox_dns.utilities import (
     name_to_unicode,
@@ -26,7 +27,7 @@ __all__ = (
 )
 
 
-class NameServer(ObjectModificationMixin, NetBoxModel):
+class NameServer(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     name = models.CharField(
         unique=True,
         max_length=255,

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -9,6 +9,7 @@ from django.db.models import Q, ExpressionWrapper, BooleanField, Min
 from django.urls import reverse
 
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from netbox.search import SearchIndex, register_search
 from netbox.plugins.utils import get_plugin_config
 from utilities.querysets import RestrictedQuerySet
@@ -62,7 +63,7 @@ class RecordManager(models.Manager.from_queryset(RestrictedQuerySet)):
         )
 
 
-class Record(ObjectModificationMixin, NetBoxModel):
+class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     ACTIVE_STATUS_LIST = (RecordStatusChoices.STATUS_ACTIVE,)
 
     unique_ptr_qs = Q(

--- a/netbox_dns/models/view.py
+++ b/netbox_dns/models/view.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.core.exceptions import ValidationError
 
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from netbox.search import SearchIndex, register_search
 from netbox.context import current_request
 from utilities.exceptions import AbortRequest
@@ -16,7 +17,7 @@ __all__ = (
 )
 
 
-class View(ObjectModificationMixin, NetBoxModel):
+class View(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     name = models.CharField(
         unique=True,
         max_length=255,

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -19,6 +19,7 @@ from django.dispatch import receiver
 from django.conf import settings
 
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from netbox.search import SearchIndex, register_search
 from netbox.plugins.utils import get_plugin_config
 from utilities.querysets import RestrictedQuerySet
@@ -67,7 +68,7 @@ class ZoneManager(models.Manager.from_queryset(RestrictedQuerySet)):
         )
 
 
-class Zone(ObjectModificationMixin, NetBoxModel):
+class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     ACTIVE_STATUS_LIST = (ZoneStatusChoices.STATUS_ACTIVE,)
 
     def __init__(self, *args, **kwargs):

--- a/netbox_dns/urls/nameserver.py
+++ b/netbox_dns/urls/nameserver.py
@@ -13,6 +13,7 @@ from netbox_dns.views import (
     NameServerBulkDeleteView,
     NameServerZoneListView,
     NameServerSOAZoneListView,
+    NameServerContactsView,
 )
 
 nameserver_urlpatterns = [
@@ -43,6 +44,11 @@ nameserver_urlpatterns = [
         "nameservers/<int:pk>/delete",
         NameServerDeleteView.as_view(),
         name="nameserver_delete",
+    ),
+    path(
+        "nameservers/<int:pk>/contacts/",
+        NameServerContactsView.as_view(),
+        name="nameserver_contacts",
     ),
     path(
         "nameservers/<int:pk>/journal/",

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -11,6 +11,7 @@ from netbox_dns.views import (
     RecordBulkImportView,
     RecordBulkEditView,
     RecordBulkDeleteView,
+    RecordContactsView,
     ManagedRecordListView,
 )
 
@@ -23,6 +24,11 @@ record_urlpatterns = [
     path("records/<int:pk>/", RecordView.as_view(), name="record"),
     path("records/<int:pk>/edit/", RecordEditView.as_view(), name="record_edit"),
     path("records/<int:pk>/delete/", RecordDeleteView.as_view(), name="record_delete"),
+    path(
+        "records/<int:pk>/contacts/",
+        RecordContactsView.as_view(),
+        name="record_contacts",
+    ),
     path(
         "records/<int:pk>/journal/",
         ObjectJournalView.as_view(),

--- a/netbox_dns/urls/view.py
+++ b/netbox_dns/urls/view.py
@@ -11,6 +11,7 @@ from netbox_dns.views import (
     ViewBulkImportView,
     ViewBulkEditView,
     ViewBulkDeleteView,
+    ViewContactsView,
     ViewZoneListView,
 )
 
@@ -23,6 +24,7 @@ view_urlpatterns = [
     path("views/<int:pk>/", ViewView.as_view(), name="view"),
     path("views/<int:pk>/edit/", ViewEditView.as_view(), name="view_edit"),
     path("views/<int:pk>/delete/", ViewDeleteView.as_view(), name="view_delete"),
+    path("views/<int:pk>/contacts/", ViewContactsView.as_view(), name="view_contacts"),
     path("views/<int:pk>/zones/", ViewZoneListView.as_view(), name="view_zones"),
     path(
         "views/<int:pk>/journal/",

--- a/netbox_dns/urls/zone.py
+++ b/netbox_dns/urls/zone.py
@@ -11,6 +11,7 @@ from netbox_dns.views import (
     ZoneBulkImportView,
     ZoneBulkEditView,
     ZoneBulkDeleteView,
+    ZoneContactsView,
     ZoneRecordListView,
     ZoneManagedRecordListView,
     ZoneRegistrationView,
@@ -27,6 +28,7 @@ zone_urlpatterns = [
     path("zones/<int:pk>/", ZoneView.as_view(), name="zone"),
     path("zones/<int:pk>/delete/", ZoneDeleteView.as_view(), name="zone_delete"),
     path("zones/<int:pk>/edit/", ZoneEditView.as_view(), name="zone_edit"),
+    path("zones/<int:pk>/contacts/", ZoneContactsView.as_view(), name="zone_contacts"),
     path("zones/<int:pk>/records/", ZoneRecordListView.as_view(), name="zone_records"),
     path(
         "zones/<int:pk>/managedrecords/",

--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -2,6 +2,7 @@ from dns import name as dns_name
 
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
+from tenancy.views import ObjectContactsView
 
 from netbox_dns.filtersets import NameServerFilterSet, ZoneFilterSet
 from netbox_dns.forms import (
@@ -24,6 +25,7 @@ __all__ = (
     "NameServerBulkDeleteView",
     "NameServerZoneListView",
     "NameServerSOAZoneListView",
+    "NameServerContactsView",
 )
 
 
@@ -75,6 +77,11 @@ class NameServerBulkEditView(generic.BulkEditView):
 class NameServerBulkDeleteView(generic.BulkDeleteView):
     queryset = NameServer.objects.all()
     table = NameServerTable
+
+
+@register_model_view(NameServer, "contacts")
+class NameServerContactsView(ObjectContactsView):
+    queryset = NameServer.objects.all()
 
 
 @register_model_view(NameServer, "zones")

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -1,6 +1,8 @@
 from dns import name as dns_name
 
 from netbox.views import generic
+from utilities.views import register_model_view
+from tenancy.views import ObjectContactsView
 
 from netbox_dns.filtersets import RecordFilterSet
 from netbox_dns.forms import (
@@ -24,6 +26,7 @@ __all__ = (
     "RecordBulkImportView",
     "RecordBulkEditView",
     "RecordBulkDeleteView",
+    "RecordContactsView",
 )
 
 
@@ -155,3 +158,8 @@ class RecordBulkEditView(generic.BulkEditView):
 class RecordBulkDeleteView(generic.BulkDeleteView):
     queryset = Record.objects.filter(managed=False)
     table = RecordTable
+
+
+@register_model_view(Record, "contacts")
+class RecordContactsView(ObjectContactsView):
+    queryset = Record.objects.all()

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -1,6 +1,8 @@
 from utilities.views import ViewTab, register_model_view
 
 from netbox.views import generic
+from utilities.views import register_model_view
+from tenancy.views import ObjectContactsView
 
 from netbox_dns.models import View, Zone
 from netbox_dns.filtersets import ViewFilterSet, ZoneFilterSet
@@ -16,6 +18,7 @@ __all__ = (
     "ViewBulkImportView",
     "ViewBulkEditView",
     "ViewBulkDeleteView",
+    "ViewContactsView",
     "ViewZoneListView",
 )
 
@@ -79,3 +82,8 @@ class ViewZoneListView(generic.ObjectChildrenView):
 
     def get_children(self, request, parent):
         return parent.zone_set
+
+
+@register_model_view(View, "contacts")
+class ViewContactsView(ObjectContactsView):
+    queryset = View.objects.all()

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -2,6 +2,7 @@ from dns import name as dns_name
 
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
+from tenancy.views import ObjectContactsView
 
 from netbox_dns.filtersets import ZoneFilterSet, RecordFilterSet
 from netbox_dns.forms import (
@@ -26,6 +27,7 @@ __all__ = (
     "ZoneBulkImportView",
     "ZoneBulkEditView",
     "ZoneBulkDeleteView",
+    "ZoneContactsView",
     "ZoneRegistrationView",
     "ZoneRecordListView",
     "ZoneManagedRecordListView",
@@ -201,3 +203,8 @@ class ZoneChildZoneListView(generic.ObjectChildrenView):
 
     def get_children(self, request, parent):
         return parent.child_zones
+
+
+@register_model_view(Zone, "contacts")
+class ZoneContactsView(ObjectContactsView):
+    queryset = Zone.objects.all()


### PR DESCRIPTION
Co-authored-by: 12158973+ThomasADavis@users.noreply.github.com

This PR is based on #371 by @ThomasADavis. 

It adds the option to add tenancy contacts to `View`, `Zone`, `NameServer` and `Record` objects. This is a standard functionality of NetBox that can be used by any model, but it's somewhat hard to figure out how to implement it. After Thomas invested a substantial amount of work in finding out what to do, I just put the missing keystone in and it worked.