### PR TITLE
Use get_model_urls to reduce complexity in URL registration

### DIFF
--- a/netbox_dns/urls/contact.py
+++ b/netbox_dns/urls/contact.py
@@ -1,51 +1,29 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import Contact
 from netbox_dns.views import (
-    ContactListView,
     ContactView,
-    ContactDeleteView,
+    ContactListView,
     ContactEditView,
+    ContactDeleteView,
     ContactBulkImportView,
     ContactBulkEditView,
     ContactBulkDeleteView,
-    ContactZoneListView,
 )
 
 contact_urlpatterns = [
+    path("contacts/<int:pk>/", ContactView.as_view(), name="contact"),
     path("contacts/", ContactListView.as_view(), name="contact_list"),
     path("contacts/add/", ContactEditView.as_view(), name="contact_add"),
+    path("contacts/<int:pk>/edit/", ContactEditView.as_view(), name="contact_edit"),
+    path(
+        "contacts/<int:pk>/delete/", ContactDeleteView.as_view(), name="contact_delete"
+    ),
     path("contacts/import/", ContactBulkImportView.as_view(), name="contact_import"),
     path("contacts/edit/", ContactBulkEditView.as_view(), name="contact_bulk_edit"),
     path(
-        "contacts/delete/",
-        ContactBulkDeleteView.as_view(),
-        name="contact_bulk_delete",
+        "contacts/delete/", ContactBulkDeleteView.as_view(), name="contact_bulk_delete"
     ),
-    path("contacts/<int:pk>/", ContactView.as_view(), name="contact"),
-    path("contacts/<int:pk>/edit/", ContactEditView.as_view(), name="contact_edit"),
-    path(
-        "contacts/<int:pk>/delete/",
-        ContactDeleteView.as_view(),
-        name="contact_delete",
-    ),
-    path(
-        "contacts/<int:pk>/zones/",
-        ContactZoneListView.as_view(),
-        name="contact_zones",
-    ),
-    path(
-        "contacts/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="contact_journal",
-        kwargs={"model": Contact},
-    ),
-    path(
-        "contacts/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="contact_changelog",
-        kwargs={"model": Contact},
-    ),
+    path("contacts/<int:pk>/", include(get_model_urls("netbox_dns", "contact"))),
 ]

--- a/netbox_dns/urls/nameserver.py
+++ b/netbox_dns/urls/nameserver.py
@@ -1,24 +1,31 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import NameServer
 from netbox_dns.views import (
-    NameServerListView,
     NameServerView,
+    NameServerListView,
     NameServerEditView,
     NameServerDeleteView,
     NameServerBulkImportView,
     NameServerBulkEditView,
     NameServerBulkDeleteView,
-    NameServerZoneListView,
-    NameServerSOAZoneListView,
-    NameServerContactsView,
 )
 
 nameserver_urlpatterns = [
+    path("nameservers/<int:pk>/", NameServerView.as_view(), name="nameserver"),
     path("nameservers/", NameServerListView.as_view(), name="nameserver_list"),
     path("nameservers/add/", NameServerEditView.as_view(), name="nameserver_add"),
+    path(
+        "nameservers/<int:pk>/edit",
+        NameServerEditView.as_view(),
+        name="nameserver_edit",
+    ),
+    path(
+        "nameservers/<int:pk>/delete",
+        NameServerDeleteView.as_view(),
+        name="nameserver_delete",
+    ),
     path(
         "nameservers/import/",
         NameServerBulkImportView.as_view(),
@@ -34,42 +41,5 @@ nameserver_urlpatterns = [
         NameServerBulkDeleteView.as_view(),
         name="nameserver_bulk_delete",
     ),
-    path("nameservers/<int:pk>/", NameServerView.as_view(), name="nameserver"),
-    path(
-        "nameservers/<int:pk>/edit",
-        NameServerEditView.as_view(),
-        name="nameserver_edit",
-    ),
-    path(
-        "nameservers/<int:pk>/delete",
-        NameServerDeleteView.as_view(),
-        name="nameserver_delete",
-    ),
-    path(
-        "nameservers/<int:pk>/contacts/",
-        NameServerContactsView.as_view(),
-        name="nameserver_contacts",
-    ),
-    path(
-        "nameservers/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="nameserver_journal",
-        kwargs={"model": NameServer},
-    ),
-    path(
-        "nameservers/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="nameserver_changelog",
-        kwargs={"model": NameServer},
-    ),
-    path(
-        "nameservers/<int:pk>/zones/",
-        NameServerZoneListView.as_view(),
-        name="nameserver_zones",
-    ),
-    path(
-        "nameservers/<int:pk>/soazones/",
-        NameServerSOAZoneListView.as_view(),
-        name="nameserver_soa_zones",
-    ),
+    path("nameservers/<int:pk>/", include(get_model_urls("netbox_dns", "nameserver"))),
 ]

--- a/netbox_dns/urls/record.py
+++ b/netbox_dns/urls/record.py
@@ -1,46 +1,28 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import Record
 from netbox_dns.views import (
-    RecordListView,
     RecordView,
+    RecordListView,
     RecordEditView,
     RecordDeleteView,
     RecordBulkImportView,
     RecordBulkEditView,
     RecordBulkDeleteView,
-    RecordContactsView,
     ManagedRecordListView,
 )
 
 record_urlpatterns = [
+    path("records/<int:pk>/", RecordView.as_view(), name="record"),
     path("records/", RecordListView.as_view(), name="record_list"),
     path("records/add/", RecordEditView.as_view(), name="record_add"),
+    path("records/<int:pk>/edit/", RecordEditView.as_view(), name="record_edit"),
+    path("records/<int:pk>/delete/", RecordDeleteView.as_view(), name="record_delete"),
     path("records/import/", RecordBulkImportView.as_view(), name="record_import"),
     path("records/edit/", RecordBulkEditView.as_view(), name="record_bulk_edit"),
     path("records/delete/", RecordBulkDeleteView.as_view(), name="record_bulk_delete"),
-    path("records/<int:pk>/", RecordView.as_view(), name="record"),
-    path("records/<int:pk>/edit/", RecordEditView.as_view(), name="record_edit"),
-    path("records/<int:pk>/delete/", RecordDeleteView.as_view(), name="record_delete"),
-    path(
-        "records/<int:pk>/contacts/",
-        RecordContactsView.as_view(),
-        name="record_contacts",
-    ),
-    path(
-        "records/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="record_journal",
-        kwargs={"model": Record},
-    ),
-    path(
-        "records/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="record_changelog",
-        kwargs={"model": Record},
-    ),
+    path("records/<int:pk>/", include(get_model_urls("netbox_dns", "record"))),
     path(
         "managedrecords/", ManagedRecordListView.as_view(), name="managed_record_list"
     ),

--- a/netbox_dns/urls/record_template.py
+++ b/netbox_dns/urls/record_template.py
@@ -1,11 +1,10 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import RecordTemplate
 from netbox_dns.views import (
-    RecordTemplateListView,
     RecordTemplateView,
+    RecordTemplateListView,
     RecordTemplateEditView,
     RecordTemplateDeleteView,
     RecordTemplateBulkImportView,
@@ -15,12 +14,25 @@ from netbox_dns.views import (
 
 recordtemplate_urlpatterns = [
     path(
+        "recordtemplates/<int:pk>/", RecordTemplateView.as_view(), name="recordtemplate"
+    ),
+    path(
         "recordtemplates/", RecordTemplateListView.as_view(), name="recordtemplate_list"
     ),
     path(
         "recordtemplates/add/",
         RecordTemplateEditView.as_view(),
         name="recordtemplate_add",
+    ),
+    path(
+        "recordtemplates/<int:pk>/edit/",
+        RecordTemplateEditView.as_view(),
+        name="recordtemplate_edit",
+    ),
+    path(
+        "recordtemplates/<int:pk>/delete/",
+        RecordTemplateDeleteView.as_view(),
+        name="recordtemplate_delete",
     ),
     path(
         "recordtemplates/import/",
@@ -38,28 +50,7 @@ recordtemplate_urlpatterns = [
         name="recordtemplate_bulk_delete",
     ),
     path(
-        "recordtemplates/<int:pk>/", RecordTemplateView.as_view(), name="recordtemplate"
-    ),
-    path(
-        "recordtemplates/<int:pk>/edit/",
-        RecordTemplateEditView.as_view(),
-        name="recordtemplate_edit",
-    ),
-    path(
-        "recordtemplates/<int:pk>/delete/",
-        RecordTemplateDeleteView.as_view(),
-        name="recordtemplate_delete",
-    ),
-    path(
-        "recordtemplates/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="recordtemplate_journal",
-        kwargs={"model": RecordTemplate},
-    ),
-    path(
-        "recordtemplates/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="recordtemplate_changelog",
-        kwargs={"model": RecordTemplate},
+        "recordtemplates/<int:pk>/",
+        include(get_model_urls("netbox_dns", "recordtemplate")),
     ),
 ]

--- a/netbox_dns/urls/registrar.py
+++ b/netbox_dns/urls/registrar.py
@@ -1,63 +1,39 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import Registrar
 from netbox_dns.views import (
-    RegistrarListView,
     RegistrarView,
-    RegistrarDeleteView,
+    RegistrarListView,
     RegistrarEditView,
+    RegistrarDeleteView,
     RegistrarBulkImportView,
     RegistrarBulkEditView,
     RegistrarBulkDeleteView,
-    RegistrarZoneListView,
 )
 
 registrar_urlpatterns = [
+    path("registrars/<int:pk>/", RegistrarView.as_view(), name="registrar"),
     path("registrars/", RegistrarListView.as_view(), name="registrar_list"),
     path("registrars/add/", RegistrarEditView.as_view(), name="registrar_add"),
     path(
-        "registrars/import/",
-        RegistrarBulkImportView.as_view(),
-        name="registrar_import",
-    ),
-    path(
-        "registrars/edit/",
-        RegistrarBulkEditView.as_view(),
-        name="registrar_bulk_edit",
+        "registrars/<int:pk>/edit/", RegistrarEditView.as_view(), name="registrar_edit"
     ),
     path(
         "registrars/delete/",
         RegistrarBulkDeleteView.as_view(),
         name="registrar_bulk_delete",
     ),
-    path("registrars/<int:pk>/", RegistrarView.as_view(), name="registrar"),
     path(
-        "registrars/<int:pk>/edit/",
-        RegistrarEditView.as_view(),
-        name="registrar_edit",
+        "registrars/import/", RegistrarBulkImportView.as_view(), name="registrar_import"
+    ),
+    path(
+        "registrars/edit/", RegistrarBulkEditView.as_view(), name="registrar_bulk_edit"
     ),
     path(
         "registrars/<int:pk>/delete/",
         RegistrarDeleteView.as_view(),
         name="registrar_delete",
     ),
-    path(
-        "registrars/<int:pk>/zones/",
-        RegistrarZoneListView.as_view(),
-        name="registrar_zones",
-    ),
-    path(
-        "registrars/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="registrar_journal",
-        kwargs={"model": Registrar},
-    ),
-    path(
-        "registrars/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="registrar_changelog",
-        kwargs={"model": Registrar},
-    ),
+    path("registrars/<int:pk>/", include(get_model_urls("netbox_dns", "registrar"))),
 ]

--- a/netbox_dns/urls/view.py
+++ b/netbox_dns/urls/view.py
@@ -1,41 +1,25 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import View
 from netbox_dns.views import (
-    ViewListView,
     ViewView,
-    ViewDeleteView,
+    ViewListView,
     ViewEditView,
+    ViewDeleteView,
     ViewBulkImportView,
     ViewBulkEditView,
     ViewBulkDeleteView,
-    ViewContactsView,
-    ViewZoneListView,
 )
 
 view_urlpatterns = [
+    path("views/<int:pk>/", ViewView.as_view(), name="view"),
     path("views/", ViewListView.as_view(), name="view_list"),
     path("views/add/", ViewEditView.as_view(), name="view_add"),
+    path("views/<int:pk>/edit/", ViewEditView.as_view(), name="view_edit"),
+    path("views/<int:pk>/delete/", ViewDeleteView.as_view(), name="view_delete"),
     path("views/import/", ViewBulkImportView.as_view(), name="view_import"),
     path("views/edit/", ViewBulkEditView.as_view(), name="view_bulk_edit"),
     path("views/delete/", ViewBulkDeleteView.as_view(), name="view_bulk_delete"),
-    path("views/<int:pk>/", ViewView.as_view(), name="view"),
-    path("views/<int:pk>/edit/", ViewEditView.as_view(), name="view_edit"),
-    path("views/<int:pk>/delete/", ViewDeleteView.as_view(), name="view_delete"),
-    path("views/<int:pk>/contacts/", ViewContactsView.as_view(), name="view_contacts"),
-    path("views/<int:pk>/zones/", ViewZoneListView.as_view(), name="view_zones"),
-    path(
-        "views/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="view_journal",
-        kwargs={"model": View},
-    ),
-    path(
-        "views/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="view_changelog",
-        kwargs={"model": View},
-    ),
+    path("views/<int:pk>/", include(get_model_urls("netbox_dns", "view"))),
 ]

--- a/netbox_dns/urls/zone.py
+++ b/netbox_dns/urls/zone.py
@@ -1,65 +1,25 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import Zone
 from netbox_dns.views import (
-    ZoneListView,
     ZoneView,
-    ZoneDeleteView,
+    ZoneListView,
     ZoneEditView,
+    ZoneDeleteView,
     ZoneBulkImportView,
     ZoneBulkEditView,
     ZoneBulkDeleteView,
-    ZoneContactsView,
-    ZoneRecordListView,
-    ZoneManagedRecordListView,
-    ZoneRegistrationView,
-    ZoneRFC2317ChildZoneListView,
-    ZoneChildZoneListView,
 )
 
 zone_urlpatterns = [
+    path("zones/<int:pk>/", ZoneView.as_view(), name="zone"),
     path("zones/", ZoneListView.as_view(), name="zone_list"),
     path("zones/add/", ZoneEditView.as_view(), name="zone_add"),
+    path("zones/<int:pk>/edit/", ZoneEditView.as_view(), name="zone_edit"),
+    path("zones/<int:pk>/delete/", ZoneDeleteView.as_view(), name="zone_delete"),
     path("zones/import/", ZoneBulkImportView.as_view(), name="zone_import"),
     path("zones/edit/", ZoneBulkEditView.as_view(), name="zone_bulk_edit"),
     path("zones/delete/", ZoneBulkDeleteView.as_view(), name="zone_bulk_delete"),
-    path("zones/<int:pk>/", ZoneView.as_view(), name="zone"),
-    path("zones/<int:pk>/delete/", ZoneDeleteView.as_view(), name="zone_delete"),
-    path("zones/<int:pk>/edit/", ZoneEditView.as_view(), name="zone_edit"),
-    path("zones/<int:pk>/contacts/", ZoneContactsView.as_view(), name="zone_contacts"),
-    path("zones/<int:pk>/records/", ZoneRecordListView.as_view(), name="zone_records"),
-    path(
-        "zones/<int:pk>/managedrecords/",
-        ZoneManagedRecordListView.as_view(),
-        name="zone_managed_records",
-    ),
-    path(
-        "zones/<int:pk>/rfc2317childzones/",
-        ZoneRFC2317ChildZoneListView.as_view(),
-        name="zone_rfc2317_child_zones",
-    ),
-    path(
-        "zones/<int:pk>/childzones/",
-        ZoneChildZoneListView.as_view(),
-        name="zone_child_zones",
-    ),
-    path(
-        "zones/<int:pk>/registration/",
-        ZoneRegistrationView.as_view(),
-        name="zone_registration",
-    ),
-    path(
-        "zones/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="zone_journal",
-        kwargs={"model": Zone},
-    ),
-    path(
-        "zones/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="zone_changelog",
-        kwargs={"model": Zone},
-    ),
+    path("zones/<int:pk>/", include(get_model_urls("netbox_dns", "zone"))),
 ]

--- a/netbox_dns/urls/zone_template.py
+++ b/netbox_dns/urls/zone_template.py
@@ -1,21 +1,31 @@
-from django.urls import path
+from django.urls import include, path
 
-from netbox.views.generic import ObjectChangeLogView, ObjectJournalView
+from utilities.urls import get_model_urls
 
-from netbox_dns.models import ZoneTemplate
 from netbox_dns.views import (
-    ZoneTemplateListView,
     ZoneTemplateView,
-    ZoneTemplateDeleteView,
+    ZoneTemplateListView,
     ZoneTemplateEditView,
+    ZoneTemplateDeleteView,
     ZoneTemplateBulkImportView,
     ZoneTemplateBulkEditView,
     ZoneTemplateBulkDeleteView,
 )
 
 zonetemplate_urlpatterns = [
+    path("zonetemplates/<int:pk>/", ZoneTemplateView.as_view(), name="zonetemplate"),
     path("zonetemplates/", ZoneTemplateListView.as_view(), name="zonetemplate_list"),
     path("zonetemplates/add/", ZoneTemplateEditView.as_view(), name="zonetemplate_add"),
+    path(
+        "zonetemplates/<int:pk>/edit/",
+        ZoneTemplateEditView.as_view(),
+        name="zonetemplate_edit",
+    ),
+    path(
+        "zonetemplates/<int:pk>/delete/",
+        ZoneTemplateDeleteView.as_view(),
+        name="zonetemplate_delete",
+    ),
     path(
         "zonetemplates/import/",
         ZoneTemplateBulkImportView.as_view(),
@@ -31,27 +41,7 @@ zonetemplate_urlpatterns = [
         ZoneTemplateBulkDeleteView.as_view(),
         name="zonetemplate_bulk_delete",
     ),
-    path("zonetemplates/<int:pk>/", ZoneTemplateView.as_view(), name="zonetemplate"),
     path(
-        "zonetemplates/<int:pk>/delete/",
-        ZoneTemplateDeleteView.as_view(),
-        name="zonetemplate_delete",
-    ),
-    path(
-        "zonetemplates/<int:pk>/edit/",
-        ZoneTemplateEditView.as_view(),
-        name="zonetemplate_edit",
-    ),
-    path(
-        "zonetemplates/<int:pk>/journal/",
-        ObjectJournalView.as_view(),
-        name="zonetemplate_journal",
-        kwargs={"model": ZoneTemplate},
-    ),
-    path(
-        "zonetemplates/<int:pk>/changelog/",
-        ObjectChangeLogView.as_view(),
-        name="zonetemplate_changelog",
-        kwargs={"model": ZoneTemplate},
+        "zonetemplates/<int:pk>/", include(get_model_urls("netbox_dns", "zonetemplate"))
     ),
 ]

--- a/netbox_dns/views/contact.py
+++ b/netbox_dns/views/contact.py
@@ -23,7 +23,6 @@ __all__ = (
     "ContactBulkImportView",
     "ContactBulkEditView",
     "ContactBulkDeleteView",
-    "ContactZoneListView",
 )
 
 

--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -16,16 +16,13 @@ from netbox_dns.tables import NameServerTable, ZoneTable
 
 
 __all__ = (
-    "NameServerListView",
     "NameServerView",
+    "NameServerListView",
     "NameServerEditView",
     "NameServerDeleteView",
     "NameServerBulkEditView",
     "NameServerBulkImportView",
     "NameServerBulkDeleteView",
-    "NameServerZoneListView",
-    "NameServerSOAZoneListView",
-    "NameServerContactsView",
 )
 
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -18,15 +18,14 @@ from netbox_dns.utilities import value_to_unicode
 
 
 __all__ = (
-    "RecordListView",
-    "ManagedRecordListView",
     "RecordView",
+    "RecordListView",
     "RecordEditView",
     "RecordDeleteView",
     "RecordBulkImportView",
     "RecordBulkEditView",
     "RecordBulkDeleteView",
-    "RecordContactsView",
+    "ManagedRecordListView",
 )
 
 

--- a/netbox_dns/views/record_template.py
+++ b/netbox_dns/views/record_template.py
@@ -15,8 +15,8 @@ from netbox_dns.utilities import value_to_unicode
 
 
 __all__ = (
-    "RecordTemplateListView",
     "RecordTemplateView",
+    "RecordTemplateListView",
     "RecordTemplateEditView",
     "RecordTemplateDeleteView",
     "RecordTemplateBulkImportView",

--- a/netbox_dns/views/registrar.py
+++ b/netbox_dns/views/registrar.py
@@ -21,7 +21,6 @@ __all__ = (
     "RegistrarBulkImportView",
     "RegistrarBulkEditView",
     "RegistrarBulkDeleteView",
-    "RegistrarZoneListView",
 )
 
 

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -1,7 +1,6 @@
 from utilities.views import ViewTab, register_model_view
 
 from netbox.views import generic
-from utilities.views import register_model_view
 from tenancy.views import ObjectContactsView
 
 from netbox_dns.models import View, Zone
@@ -18,8 +17,6 @@ __all__ = (
     "ViewBulkImportView",
     "ViewBulkEditView",
     "ViewBulkDeleteView",
-    "ViewContactsView",
-    "ViewZoneListView",
 )
 
 

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -20,19 +20,13 @@ from netbox_dns.tables import (
 
 
 __all__ = (
-    "ZoneListView",
     "ZoneView",
+    "ZoneListView",
     "ZoneEditView",
     "ZoneDeleteView",
     "ZoneBulkImportView",
     "ZoneBulkEditView",
     "ZoneBulkDeleteView",
-    "ZoneContactsView",
-    "ZoneRegistrationView",
-    "ZoneRecordListView",
-    "ZoneManagedRecordListView",
-    "ZoneRFC2317ChildZoneListView",
-    "ZoneChildZoneListView",
 )
 
 

--- a/netbox_dns/views/zone_template.py
+++ b/netbox_dns/views/zone_template.py
@@ -1,5 +1,6 @@
 from netbox.views import generic
 
+from netbox_dns.models import ZoneTemplate
 from netbox_dns.filtersets import ZoneTemplateFilterSet
 from netbox_dns.forms import (
     ZoneTemplateImportForm,
@@ -7,13 +8,12 @@ from netbox_dns.forms import (
     ZoneTemplateFilterForm,
     ZoneTemplateBulkEditForm,
 )
-from netbox_dns.models import ZoneTemplate
 from netbox_dns.tables import ZoneTemplateTable, RecordTemplateDisplayTable
 
 
 __all__ = (
-    "ZoneTemplateListView",
     "ZoneTemplateView",
+    "ZoneTemplateListView",
     "ZoneTemplateEditView",
     "ZoneTemplateDeleteView",
     "ZoneTemplateBulkImportView",


### PR DESCRIPTION
Internal improvement only - saves a couple of hundred lines of code and reduces complexity, which is always good.