### PR TITLE
fix: show managed dns records ManagedRecordListView

### DIFF
--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -39,7 +39,7 @@ class RecordListView(generic.ObjectListView):
 
 
 class ManagedRecordListView(generic.ObjectListView):
-    queryset = Record.objects.prefetch_related("ipam_ip_address", "address_record")
+    queryset = Record.objects.filter(managed=True).prefetch_related("ipam_ip_address", "address_record")
     filterset = RecordFilterSet
     filterset_form = RecordFilterForm
     table = ManagedRecordTable


### PR DESCRIPTION
fixes #396

Since ec16edba9f6694c4b33f225a1fe47cc9fa79c1e7 ManagedRecordListView shows all records instead of only the managed ones.