### PR TITLE
Remove unnecessary imports in the GraphQL schema definitions

### DIFF
--- a/netbox_dns/graphql/schema.py
+++ b/netbox_dns/graphql/schema.py
@@ -3,16 +3,6 @@ from typing import List
 import strawberry
 import strawberry_django
 
-from netbox_dns.models import (
-    NameServer,
-    View,
-    Zone,
-    Record,
-    RegistrationContact,
-    Registrar,
-    ZoneTemplate,
-    RecordTemplate,
-)
 from .types import (
     NetBoxDNSNameServerType,
     NetBoxDNSViewType,


### PR DESCRIPTION
After the recent changes there were some unused imports left in the GraphQL schema.

This PR removes the import statements.