### PR TITLE
Add an option to turn off optimisation for rebuild_dnssync

### DIFF
--- a/netbox_dns/management/commands/rebuild_dnssync.py
+++ b/netbox_dns/management/commands/rebuild_dnssync.py
@@ -8,6 +8,13 @@ from netbox_dns.utilities import update_dns_records
 class Command(BaseCommand):
     help = "Rebuild DNSsync relationships between IP addresses and records"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Update records even if DNS name was not changed (required for rebuilding filtered views",
+        )
+
     def handle(self, *model_names, **options):
         ip_addresses = IPAddress.objects.all()
         for ip_address in ip_addresses:
@@ -15,4 +22,10 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Updating DNS records for IP Address {ip_address}, VRF {ip_address.vrf}"
                 )
-            update_dns_records(ip_address)
+            if (
+                update_dns_records(ip_address, force=options.get("force"))
+                and options.get("verbosity") >= 1
+            ):
+                self.stdout.write(
+                    f"Updated DNS records for IP Address {ip_address}, VRF {ip_address.vrf}"
+                )


### PR DESCRIPTION
fixes #410

This PR turns off optimisations for the `rebuild_dnssec` management command that save much time in the general case, but may lead to an incomplete rebuild if IP address filters for views are in place. This behavior has not been made the default because in many cases it won't be necessary and in the general case it saves a lot of time.

The optimisation simply checks whether the IP address (address, DNS name and the DNSsync CFs) is still consistent with the address records associated with the address, and updating the records only if that's not the case. This does not take the case into account that the inconsistency is caused by a modified IP address filter, though, as checking that case on an individual base is expensive in terms of database operations.

By using the `--force` flag it's now possible to override the optimisation, which covers the case of modified or deleted IP address filters as well.