### PR TITLE
Add `gettext` support to NetBox DNS

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from netbox.plugins import PluginConfig
 from ipam.choices import IPAddressStatusChoices
@@ -10,8 +11,8 @@ __version__ = "1.1.2"
 
 class DNSConfig(PluginConfig):
     name = "netbox_dns"
-    verbose_name = "NetBox DNS"
-    description = "NetBox plugin for DNS data"
+    verbose_name = _("NetBox DNS")
+    description = _("NetBox plugin for DNS data")
     min_version = "4.0.0"
     version = __version__
     author = "Peter Eckel"

--- a/netbox_dns/api/nested_serializers.py
+++ b/netbox_dns/api/nested_serializers.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import WritableNestedSerializer
@@ -37,7 +38,7 @@ class NestedZoneSerializer(WritableNestedSerializer):
         many=False,
         required=False,
         read_only=True,
-        help_text="View the zone belongs to",
+        help_text=_("View the zone belongs to"),
     )
     active = serializers.BooleanField(
         required=False,
@@ -82,7 +83,7 @@ class NestedRecordSerializer(WritableNestedSerializer):
     zone = NestedZoneSerializer(
         many=False,
         required=False,
-        help_text="Zone the record belongs to",
+        help_text=_("Zone the record belongs to"),
     )
     active = serializers.BooleanField(
         required=False,

--- a/netbox_dns/api/serializers_/nameserver.py
+++ b/netbox_dns/api/serializers_/nameserver.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -20,7 +21,7 @@ class NameServerSerializer(NetBoxModelSerializer):
         read_only=True,
         required=False,
         default=None,
-        help_text="Zones served by the authoritative nameserver",
+        help_text=_("Zones served by the authoritative nameserver"),
     )
     tenant = TenantSerializer(required=False, allow_null=True)
 

--- a/netbox_dns/api/serializers_/record.py
+++ b/netbox_dns/api/serializers_/record.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -21,19 +22,19 @@ class RecordSerializer(NetBoxModelSerializer):
         read_only=True,
         required=False,
         allow_null=True,
-        help_text="PTR record generated from an address",
+        help_text=_("PTR record generated from an address"),
     )
     address_record = NestedRecordSerializer(
         many=False,
         read_only=True,
         required=False,
         allow_null=True,
-        help_text="Address record defining the PTR",
+        help_text=_("Address record defining the PTR"),
     )
     zone = NestedZoneSerializer(
         many=False,
         required=False,
-        help_text="Zone the record belongs to",
+        help_text=_("Zone the record belongs to"),
     )
     active = serializers.BooleanField(
         required=False,
@@ -45,7 +46,7 @@ class RecordSerializer(NetBoxModelSerializer):
         read_only=True,
         required=False,
         allow_null=True,
-        help_text="IPAddress linked to the record",
+        help_text=_("IPAddress linked to the record"),
     )
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
 

--- a/netbox_dns/api/serializers_/record_template.py
+++ b/netbox_dns/api/serializers_/record_template.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -20,7 +21,7 @@ class RecordTemplateSerializer(NetBoxModelSerializer):
         many=True,
         read_only=True,
         required=False,
-        help_text="Zone templates using the record template",
+        help_text=_("Zone templates using the record template"),
     )
 
     class Meta:

--- a/netbox_dns/api/serializers_/view.py
+++ b/netbox_dns/api/serializers_/view.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -22,7 +23,7 @@ class ViewSerializer(NetBoxModelSerializer):
         nested=True,
         read_only=False,
         required=False,
-        help_text="IPAM Prefixes assigned to the View",
+        help_text=_("IPAM Prefixes assigned to the View"),
     )
     tenant = TenantSerializer(
         nested=True,

--- a/netbox_dns/api/serializers_/zone.py
+++ b/netbox_dns/api/serializers_/zone.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -27,75 +28,75 @@ class ZoneSerializer(NetBoxModelSerializer):
         read_only=False,
         required=False,
         default=None,
-        help_text="View the zone belongs to",
+        help_text=_("View the zone belongs to"),
     )
     nameservers = NameServerSerializer(
         nested=True,
         many=True,
         read_only=False,
         required=False,
-        help_text="Nameservers for the zone",
+        help_text=_("Nameservers for the zone"),
     )
     soa_mname = NameServerSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="Primary nameserver for the zone",
+        help_text=_("Primary nameserver for the zone"),
     )
     rfc2317_parent_zone = NestedZoneSerializer(
         many=False,
         read_only=True,
         required=False,
-        help_text="RFC2317 arent zone for the zone",
+        help_text=_("RFC2317 parent zone of the zone"),
     )
     rfc2317_child_zones = NestedZoneSerializer(
         many=True,
         read_only=True,
         required=False,
-        help_text="RFC2317 child zones of the zone",
+        help_text=_("RFC2317 child zones of the zone"),
     )
     registrar = RegistrarSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The registrar the domain is registered with",
+        help_text=_("Registrar the domain is registered with"),
     )
     registrant = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The owner of the domain",
+        help_text=_("Registrant of the domain"),
     )
     admin_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The administrative contact for the domain",
+        help_text=_("Administrative contact for the domain"),
     )
     tech_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The technical contact for the domain",
+        help_text=_("Technical contact for the domain"),
     )
     billing_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The billing contact for the domain",
+        help_text=_("Billing contact for the domain"),
     )
     template = ZoneTemplateSerializer(
         nested=True,
         write_only=True,
         required=False,
         default=None,
-        help_text="Template to apply to the zone",
+        help_text=_("Template to apply to the zone"),
     )
     active = serializers.BooleanField(
         required=False,

--- a/netbox_dns/api/serializers_/zone_template.py
+++ b/netbox_dns/api/serializers_/zone_template.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from netbox.api.serializers import NetBoxModelSerializer
@@ -23,48 +24,48 @@ class ZoneTemplateSerializer(NetBoxModelSerializer):
         many=True,
         read_only=False,
         required=False,
-        help_text="Nameservers for the zone",
+        help_text=_("Nameservers for the zone"),
     )
     record_templates = NestedRecordTemplateSerializer(
         many=True,
         read_only=False,
         required=False,
-        help_text="Record templates assigned to the zone",
+        help_text=_("Record templates assigned to the zone template"),
     )
     registrar = RegistrarSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The registrar the domain is registered with",
+        help_text=_("Registrar the domain is registered with"),
     )
     registrant = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The owner of the domain",
+        help_text=_("Registrant of the domain"),
     )
     admin_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The administrative contact for the domain",
+        help_text=_("Administrative contact for the domain"),
     )
     tech_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The technical contact for the domain",
+        help_text=_("Technical contact for the domain"),
     )
     billing_c = RegistrationContactSerializer(
         nested=True,
         many=False,
         read_only=False,
         required=False,
-        help_text="The billing contact for the domain",
+        help_text=_("Billing contact for the domain"),
     )
     active = serializers.BooleanField(
         required=False,

--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.routers import APIRootView
 
@@ -80,7 +81,7 @@ class RecordViewSet(NetBoxModelViewSet):
             data = [data]
 
         if any(record.get("managed") for record in data):
-            raise serializers.ValidationError("'managed' is True, refusing create")
+            raise serializers.ValidationError(_("'managed' is True, refusing create"))
 
         return super().create(request, *args, **kwargs)
 
@@ -88,7 +89,7 @@ class RecordViewSet(NetBoxModelViewSet):
         v_object = self.get_object()
         if v_object.managed:
             raise serializers.ValidationError(
-                f"{v_object} is managed, refusing deletion"
+                _("{object} is managed, refusing deletion").format(object=v_object)
             )
 
         return super().destroy(request, *args, **kwargs)
@@ -96,11 +97,15 @@ class RecordViewSet(NetBoxModelViewSet):
     def update(self, request, *args, **kwargs):
         v_object = self.get_object()
         if v_object.managed:
-            raise serializers.ValidationError(f"{v_object} is managed, refusing update")
+            raise serializers.ValidationError(
+                _("{object} is managed, refusing update").format(object=v_object)
+            )
 
         if request.data.get("managed"):
             raise serializers.ValidationError(
-                f"{v_object} is unmanaged, refusing update to managed"
+                _("{object} is unmanaged, refusing update to managed").format(
+                    object=v_object
+                )
             )
 
         return super().update(request, *args, **kwargs)

--- a/netbox_dns/choices/record.py
+++ b/netbox_dns/choices/record.py
@@ -1,5 +1,7 @@
 from dns import rdatatype, rdataclass
 
+from django.utils.translation import gettext_lazy as _
+
 from utilities.choices import ChoiceSet
 
 
@@ -44,6 +46,6 @@ class RecordStatusChoices(ChoiceSet):
     STATUS_INACTIVE = "inactive"
 
     CHOICES = [
-        (STATUS_ACTIVE, "Active", "blue"),
-        (STATUS_INACTIVE, "Inactive", "red"),
+        (STATUS_ACTIVE, _("Active"), "blue"),
+        (STATUS_INACTIVE, _("Inactive"), "red"),
     ]

--- a/netbox_dns/choices/zone.py
+++ b/netbox_dns/choices/zone.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from utilities.choices import ChoiceSet
 
 
@@ -13,8 +15,8 @@ class ZoneStatusChoices(ChoiceSet):
     STATUS_PARKED = "parked"
 
     CHOICES = [
-        (STATUS_ACTIVE, "Active", "blue"),
-        (STATUS_RESERVED, "Reserved", "cyan"),
-        (STATUS_DEPRECATED, "Deprecated", "red"),
-        (STATUS_PARKED, "Parked", "gray"),
+        (STATUS_ACTIVE, _("Active"), "blue"),
+        (STATUS_RESERVED, _("Reserved"), "cyan"),
+        (STATUS_DEPRECATED, _("Deprecated"), "red"),
+        (STATUS_PARKED, _("Parked"), "gray"),
     ]

--- a/netbox_dns/fields/address.py
+++ b/netbox_dns/fields/address.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.db import models
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from netaddr import AddrFormatError, IPAddress
 
@@ -28,7 +29,7 @@ class AddressFormField(forms.Field):
 
 
 class AddressField(models.Field):
-    description = "IPv4/v6 address"
+    description = _("IPv4/v6 address")
 
     def python_type(self):
         return IPAddress

--- a/netbox_dns/fields/network.py
+++ b/netbox_dns/fields/network.py
@@ -2,6 +2,7 @@ from django import forms
 from django.db import models
 from django.db.models import Lookup, Transform, IntegerField
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from netaddr import AddrFormatError, IPNetwork
 
@@ -76,7 +77,7 @@ class NetworkFormField(forms.Field):
 
 
 class NetworkField(models.Field):
-    description = "IPv4/v6 network associated with a reverse lookup zone"
+    description = _("IPv4/v6 network associated with a reverse lookup zone")
 
     def python_type(self):
         return IPNetwork

--- a/netbox_dns/fields/rfc2317.py
+++ b/netbox_dns/fields/rfc2317.py
@@ -3,11 +3,14 @@ from netaddr import IPNetwork, AddrFormatError
 from django import forms
 from django.db import models
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from netbox_dns.validators import validate_ipv4, validate_prefix, validate_rfc2317
 from .network import NetContains, NetContained, NetOverlap, NetMaskLength
 
-INVALID_RFC2317 = "RFC2317 requires an IPv4 prefix with a length of at least 25 bits."
+INVALID_RFC2317 = _(
+    "RFC2317 requires an IPv4 prefix with a length of at least 25 bits."
+)
 
 
 __all__ = (
@@ -28,7 +31,7 @@ class RFC2317NetworkFormField(forms.Field):
             raise ValidationError(INVALID_RFC2317)
 
         if len(value.split("/")) != 2:
-            raise ValidationError("Please specify the prefix length")
+            raise ValidationError(_("Please specify the prefix length"))
 
         try:
             ip_network = IPNetwork(value)
@@ -42,7 +45,8 @@ class RFC2317NetworkFormField(forms.Field):
 
 
 class RFC2317NetworkField(models.Field):
-    description = "PostgreSQL CIDR field for an RFC2317 prefix"
+    description = _("PostgreSQL CIDR field for an RFC2317 prefix")
+
     default_validators = [validate_ipv4, validate_prefix, validate_rfc2317]
 
     def python_type(self):

--- a/netbox_dns/filtersets/nameserver.py
+++ b/netbox_dns/filtersets/nameserver.py
@@ -1,5 +1,6 @@
 import django_filters
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -15,12 +16,12 @@ class NameServerFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         field_name="zones",
         queryset=Zone.objects.all(),
         to_field_name="id",
-        label="Zones",
+        label=_("Zones"),
     )
     soa_zone_id = django_filters.ModelMultipleChoiceFilter(
         method="filter_soa_zones",
         queryset=Zone.objects.all(),
-        label="SOA Zones",
+        label=_("SOA Zones"),
     )
 
     class Meta:

--- a/netbox_dns/filtersets/record.py
+++ b/netbox_dns/filtersets/record.py
@@ -2,6 +2,7 @@ import netaddr
 
 import django_filters
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -28,52 +29,52 @@ class RecordFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     )
     zone_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Zone.objects.all(),
-        label="Parent Zone ID",
+        label=_("Parent Zone ID"),
     )
     zone = django_filters.ModelMultipleChoiceFilter(
         queryset=Zone.objects.all(),
         field_name="zone__name",
         to_field_name="name",
-        label="Parent Zone",
+        label=_("Parent Zone"),
     )
     view_id = django_filters.ModelMultipleChoiceFilter(
         queryset=View.objects.all(),
         field_name="zone__view",
-        label="ID of the View the Parent Zone belongs to",
+        label=_("ID of the View the Parent Zone belongs to"),
     )
     view = django_filters.ModelMultipleChoiceFilter(
         queryset=View.objects.all(),
         field_name="zone__view__name",
         to_field_name="name",
-        label="View the Parent Zone belongs to",
+        label=_("View the Parent Zone belongs to"),
     )
     address_record_id = django_filters.ModelMultipleChoiceFilter(
         field_name="address_record",
         queryset=Record.objects.all(),
         to_field_name="id",
-        label="Address Record",
+        label=_("Address Record"),
     )
     ptr_record_id = django_filters.ModelMultipleChoiceFilter(
         field_name="ptr_record",
         queryset=Record.objects.all(),
         to_field_name="id",
-        label="Pointer Record",
+        label=_("Pointer Record"),
     )
     rfc2317_cname_record_id = django_filters.ModelMultipleChoiceFilter(
         field_name="rfc2317_cname_record",
         queryset=Record.objects.all(),
         to_field_name="id",
-        label="Pointer Record",
+        label=_("Pointer Record"),
     )
     ipam_ip_address_id = django_filters.ModelMultipleChoiceFilter(
         field_name="ipam_ip_address",
         queryset=IPAddress.objects.all(),
         to_field_name="id",
-        label="IPAM IP Address",
+        label=_("IPAM IP Address"),
     )
     ip_address = MultiValueCharFilter(
         method="filter_ip_address",
-        label="IP Address",
+        label=_("IP Address"),
     )
 
     managed = django_filters.BooleanFilter()

--- a/netbox_dns/filtersets/record_template.py
+++ b/netbox_dns/filtersets/record_template.py
@@ -1,5 +1,6 @@
 import django_filters
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -22,13 +23,13 @@ class RecordTemplateFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         queryset=ZoneTemplate.objects.all(),
         field_name="zone_templates__name",
         to_field_name="name",
-        label="Zone Template",
+        label=_("Zone Template"),
     )
     zone_template_id = django_filters.ModelMultipleChoiceFilter(
         queryset=ZoneTemplate.objects.all(),
         field_name="zone_templates",
         to_field_name="id",
-        label="Zone Template ID",
+        label=_("Zone Template ID"),
     )
 
     class Meta:

--- a/netbox_dns/filtersets/view.py
+++ b/netbox_dns/filtersets/view.py
@@ -1,6 +1,7 @@
 import django_filters
 
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -17,13 +18,13 @@ class ViewFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
         queryset=Prefix.objects.all(),
         field_name="prefixes",
         to_field_name="id",
-        label="Prefixes ID",
+        label=_("Prefix ID"),
     )
     prefix = django_filters.ModelMultipleChoiceFilter(
         queryset=Prefix.objects.all(),
         field_name="prefixes__prefix",
         to_field_name="prefix",
-        label="Prefix",
+        label=_("Prefix"),
     )
 
     class Meta:

--- a/netbox_dns/filtersets/zone.py
+++ b/netbox_dns/filtersets/zone.py
@@ -2,6 +2,8 @@ import netaddr
 
 import django_filters
 from django.db.models import Q
+from django.utils.translation import gettext as _
+from django.utils.translation import pgettext as _p
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -20,69 +22,69 @@ class ZoneFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     )
     view_id = django_filters.ModelMultipleChoiceFilter(
         queryset=View.objects.all(),
-        label="View ID",
+        label=_("View ID"),
     )
     view = django_filters.ModelMultipleChoiceFilter(
         queryset=View.objects.all(),
         field_name="view__name",
         to_field_name="name",
-        label="View",
+        label=_p("DNS", "View"),
     )
     # DEPRECATED: Remove in 1.1
     name_server_id = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers",
         to_field_name="id",
-        label="Nameserver IDs",
+        label=_("Nameserver IDs"),
     )
     # DEPRECATED: Remove in 1.1
     name_server = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers__name",
         to_field_name="name",
-        label="Nameservers",
+        label=_("Nameservers"),
     )
     nameserver_id = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers",
         to_field_name="id",
-        label="Nameservers ID",
+        label=_("Nameservers ID"),
     )
     nameserver = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers__name",
         to_field_name="name",
-        label="Nameserver",
+        label=_("Nameserver"),
     )
     soa_mname_id = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
-        label="SOA MName ID",
+        label=_("SOA MName ID"),
     )
     soa_mname = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="soa_mname__name",
         to_field_name="name",
-        label="SOA MName",
+        label=_("SOA MName"),
     )
     arpa_network = MultiValueCharFilter(
         method="filter_arpa_network",
-        label="ARPA Network",
+        label=_("ARPA Network"),
     )
     rfc2317_prefix = MultiValueCharFilter(
         method="filter_rfc2317_prefix",
-        label="RFC2317 Prefix",
+        label=_("RFC2317 Prefix"),
     )
     rfc2317_parent_zone_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Zone.objects.all(),
         field_name="rfc2317_parent_zone",
         to_field_name="id",
-        label="RFC2317 Parent Zone",
+        label=_("RFC2317 Parent Zone"),
     )
     rfc2317_parent_zone = django_filters.ModelMultipleChoiceFilter(
         queryset=Zone.objects.all(),
         field_name="rfc2317_parent_zone__name",
         to_field_name="name",
-        label="RFC2317 Parent Zone",
+        label=_("RFC2317 Parent Zone"),
     )
     registrar_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Registrar.objects.all(),
@@ -92,50 +94,50 @@ class ZoneFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         queryset=Registrar.objects.all(),
         field_name="registrar__name",
         to_field_name="name",
-        label="Registrar",
+        label=_("Registrar"),
     )
     registrant_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Registrant ID",
+        label=_("Registrant ID"),
     )
     registrant = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="registrant__contact_id",
         to_field_name="contact_id",
-        label="Registrant",
+        label=_("Registrant"),
     )
     admin_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Administrative RegistrationContact ID",
+        label=_("Administrative Contact ID"),
     )
     admin_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="admin_c__contact_id",
         to_field_name="contact_id",
-        label="Administrative RegistrationContact",
+        label=_("Administrative Contact"),
     )
     tech_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Technical RegistrationContact ID",
+        label=_("Technical Contact ID"),
     )
     tech_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="tech_c__contact_id",
         to_field_name="contact_id",
-        label="Technical RegistrationContact",
+        label=_("Technical Contact"),
     )
     billing_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Billing RegistrationContact ID",
+        label=_("Billing Contact ID"),
     )
     billing_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="billing_c__contact_id",
         to_field_name="contact_id",
-        label="Billing RegistrationContact",
+        label=_("Billing Contact"),
     )
     active = django_filters.BooleanFilter(
-        label="Zone is active",
+        label=_("Zone is active"),
     )
 
     class Meta:

--- a/netbox_dns/filtersets/zone_template.py
+++ b/netbox_dns/filtersets/zone_template.py
@@ -1,6 +1,7 @@
 import django_filters
 
 from django.db.models import Q
+from django.utils.translation import gettext as _
 
 from netbox.filtersets import NetBoxModelFilterSet
 from tenancy.filtersets import TenancyFilterSet
@@ -22,75 +23,75 @@ class ZoneTemplateFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         queryset=RecordTemplate.objects.all(),
         field_name="record_templates",
         to_field_name="id",
-        label="Record Template ID",
+        label=_("Record Template ID"),
     )
     record_template = django_filters.ModelMultipleChoiceFilter(
         queryset=RecordTemplate.objects.all(),
         field_name="record_templates__name",
         to_field_name="name",
-        label="Record Template",
+        label=_("Record Template"),
     )
     nameserver_id = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers",
         to_field_name="id",
-        label="Nameservers ID",
+        label=_("Nameservers ID"),
     )
     nameserver = django_filters.ModelMultipleChoiceFilter(
         queryset=NameServer.objects.all(),
         field_name="nameservers__name",
         to_field_name="name",
-        label="Nameserver",
+        label=_("Nameserver"),
     )
     registrar_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Registrar.objects.all(),
-        label="Registrar ID",
+        label=_("Registrar ID"),
     )
     registrar = django_filters.ModelMultipleChoiceFilter(
         queryset=Registrar.objects.all(),
         field_name="registrar__name",
         to_field_name="name",
-        label="Registrar",
+        label=_("Registrar"),
     )
     registrant_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Registrant ID",
+        label=_("Registrant ID"),
     )
     registrant = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="registrant__contact_id",
         to_field_name="contact_id",
-        label="Registrant",
+        label=_("Registrant"),
     )
     admin_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Administrative RegistrationContact ID",
+        label=_("Administrative Contact ID"),
     )
     admin_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="admin_c__contact_id",
         to_field_name="contact_id",
-        label="Administrative RegistrationContact",
+        label=_("Administrative Contact"),
     )
     tech_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Technical RegistrationContact ID",
+        label=_("Technical Contact ID"),
     )
     tech_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="tech_c__contact_id",
         to_field_name="contact_id",
-        label="Technical RegistrationContact",
+        label=_("Technical Contact"),
     )
     billing_c_id = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
-        label="Billing RegistrationContact ID",
+        label=_("Billing Contact ID"),
     )
     billing_c = django_filters.ModelMultipleChoiceFilter(
         queryset=RegistrationContact.objects.all(),
         field_name="billing_c__contact_id",
         to_field_name="contact_id",
-        label="Billing RegistrationContact",
+        label=_("Billing Contact"),
     )
 
     class Meta:

--- a/netbox_dns/forms/nameserver.py
+++ b/netbox_dns/forms/nameserver.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -37,10 +38,15 @@ class NameServerForm(TenancyForm, NetBoxModelForm):
         if initial_name:
             self.initial["name"] = name_to_unicode(initial_name)
 
+    name = forms.CharField(
+        required=True,
+        label=_("Name"),
+    )
+
     fieldsets = (
-        FieldSet("name", "description", name="Nameserver"),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
-        FieldSet("tags", name="Tags"),
+        FieldSet("name", "description", name=_("Nameserver")),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
+        FieldSet("tags", name=_("Tags")),
     )
 
     class Meta:
@@ -51,37 +57,42 @@ class NameServerForm(TenancyForm, NetBoxModelForm):
 class NameServerFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = NameServer
 
+    name = forms.CharField(
+        required=False,
+        label=_("Name"),
+    )
     zone_id = DynamicModelMultipleChoiceField(
         queryset=Zone.objects.all(),
         required=False,
-        label="Zones",
+        label=_("Zones"),
     )
     soa_zone_id = DynamicModelMultipleChoiceField(
         queryset=Zone.objects.all(),
         required=False,
-        label="SOA Zones",
-    )
-    name = forms.CharField(
-        required=False,
+        label=_("SOA Zones"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     tag = TagFilterField(NameServer)
 
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("name", "zone_id", "soa_zone_id", "description", name="Attributes"),
-        FieldSet("tenant_group_id", "tenant_id", name="Tenancy"),
+        FieldSet("name", "zone_id", "soa_zone_id", "description", name=_("Attributes")),
+        FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
     )
 
 
 class NameServerImportForm(NetBoxModelImportForm):
+    name = forms.CharField(
+        label=_("Name"),
+    )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Assigned tenant",
+        label=_("Tenant"),
     )
 
     class Meta:
@@ -98,16 +109,23 @@ class NameServerImportForm(NetBoxModelImportForm):
 class NameServerBulkEditForm(NetBoxModelBulkEditForm):
     model = NameServer
 
-    description = forms.CharField(max_length=200, required=False)
-    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
+    description = forms.CharField(
+        max_length=200,
+        required=False,
+        label=_("Description"),
+    )
+    tenant = DynamicModelChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+    )
 
     fieldsets = (
         FieldSet(
-            "name",
             "description",
             "tenant",
             "tags",
-            name="Attributes",
+            name=_("Attributes"),
         ),
     )
 

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -49,7 +51,7 @@ class RecordForm(TenancyForm, NetBoxModelForm):
     view = DynamicModelChoiceField(
         queryset=View.objects.all(),
         required=False,
-        label="View",
+        label=_p("DNS", "View"),
     )
     zone = DynamicModelChoiceField(
         queryset=Zone.objects.all(),
@@ -57,16 +59,16 @@ class RecordForm(TenancyForm, NetBoxModelForm):
         query_params={
             "view_id": "$view",
         },
-        label="Zone",
+        label=_("Zone"),
     )
 
     disable_ptr = forms.BooleanField(
-        label="Disable PTR",
         required=False,
+        label=_("Disable PTR"),
     )
     ttl = forms.IntegerField(
         required=False,
-        label="TTL",
+        label=_("TTL"),
     )
 
     fieldsets = (
@@ -82,8 +84,8 @@ class RecordForm(TenancyForm, NetBoxModelForm):
             "description",
             name="Record",
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
-        FieldSet("tags", name="Tags"),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
+        FieldSet("tags", name=_("Tags")),
     )
 
     class Meta:
@@ -116,41 +118,46 @@ class RecordFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
             "disable_ptr",
             "status",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
-        FieldSet("tenant_group_id", "tenant_id", name="Tenancy"),
+        FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
     )
 
     type = forms.MultipleChoiceField(
         choices=RecordTypeChoices,
         required=False,
+        label=_("Type"),
     )
     name = forms.CharField(
         required=False,
+        label=_("Name"),
     )
     fqdn = forms.CharField(
         required=False,
-        label="FQDN",
+        label=_("FQDN"),
     )
     value = forms.CharField(
         required=False,
+        label=_("Value"),
     )
     disable_ptr = forms.NullBooleanField(
         required=False,
-        label="Disable PTR",
         widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        label=_("Disable PTR"),
     )
     status = forms.MultipleChoiceField(
         choices=RecordStatusChoices,
         required=False,
+        label=_("Status"),
     )
     zone_id = DynamicModelMultipleChoiceField(
         queryset=Zone.objects.all(),
         required=False,
-        label="Zone",
+        label=_("Zone"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     tag = TagFilterField(Record)
 
@@ -177,38 +184,37 @@ class RecordImportForm(NetBoxModelImportForm):
         queryset=Zone.objects.all(),
         to_field_name="name",
         required=True,
-        help_text="Zone",
+        label=_("Zone"),
     )
     view = CSVModelChoiceField(
         queryset=View.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="View the zone belongs to",
+        label=_p("DNS", "View"),
     )
     type = CSVChoiceField(
         choices=RecordTypeChoices,
         required=True,
-        help_text="Record Type",
+        label=_("Type"),
     )
     status = CSVChoiceField(
         choices=RecordStatusChoices,
         required=False,
-        help_text="Record status",
+        label=_("Status"),
     )
     ttl = forms.IntegerField(
         required=False,
-        help_text="TTL",
+        label=_("TTL"),
     )
     disable_ptr = forms.BooleanField(
         required=False,
-        label="Disable PTR",
-        help_text="Disable generation of a PTR record",
+        label=_("Disable PTR"),
     )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Assigned tenant",
+        label=_("Tenant"),
     )
 
     def is_valid(self):
@@ -242,35 +248,40 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
     zone = DynamicModelChoiceField(
         queryset=Zone.objects.all(),
         required=False,
+        label=_("Zone"),
     )
     type = forms.ChoiceField(
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
+        label=_("Type"),
     )
     value = forms.CharField(
         required=False,
-        label="Value",
+        label=_("Value"),
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(RecordStatusChoices),
         required=False,
+        label=_("Status"),
     )
     ttl = forms.IntegerField(
         required=False,
-        label="TTL",
+        label=_("TTL"),
     )
     disable_ptr = forms.NullBooleanField(
         required=False,
-        label="Disable PTR",
         widget=BulkEditNullBooleanSelect(),
+        label=_("Disable PTR"),
     )
     description = forms.CharField(
         max_length=200,
         required=False,
+        label=_("Description"),
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
+        label=_("Tenant"),
     )
 
     fieldsets = (
@@ -282,8 +293,8 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
             "ttl",
             "disable_ptr",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
     )
     nullable_fields = ("description", "ttl", "tenant")

--- a/netbox_dns/forms/record_template.py
+++ b/netbox_dns/forms/record_template.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -41,12 +42,12 @@ class RecordTemplateForm(TenancyForm, NetBoxModelForm):
             self.initial["record_name"] = name_to_unicode(initial_record_name)
 
     disable_ptr = forms.BooleanField(
-        label="Disable PTR",
         required=False,
+        label=_("Disable PTR"),
     )
     ttl = forms.IntegerField(
         required=False,
-        label="TTL",
+        label=_("TTL"),
     )
 
     fieldsets = (
@@ -59,10 +60,10 @@ class RecordTemplateForm(TenancyForm, NetBoxModelForm):
             "ttl",
             "disable_ptr",
             "description",
-            name="Record Template",
+            name=_("Record Template"),
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
-        FieldSet("tags", name="Tags"),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
+        FieldSet("tags", name=_("Tags")),
     )
 
     class Meta:
@@ -93,44 +94,47 @@ class RecordTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
             "value",
             "status",
             "disable_ptr",
-            "status",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
-        FieldSet("zone_template_id", name="Zone Templates"),
-        FieldSet("tenant_group_id", "tenant_id", name="Tenancy"),
+        FieldSet("zone_template_id", name=_("Zone Templates")),
+        FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
     )
 
     type = forms.MultipleChoiceField(
         choices=RecordTypeChoices,
         required=False,
+        label=_("Type"),
     )
     name = forms.CharField(
         required=False,
-        label="Template name",
+        label=_("Template Name"),
     )
     record_name = forms.CharField(
         required=False,
-        label="Name",
+        label=_("Name"),
     )
     value = forms.CharField(
         required=False,
+        label=_("Value"),
     )
     status = forms.MultipleChoiceField(
         choices=RecordStatusChoices,
         required=False,
+        label=_("Status"),
     )
     disable_ptr = forms.NullBooleanField(
         required=False,
-        label="Disable PTR",
+        label=_("Disable PTR"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     zone_template_id = DynamicModelMultipleChoiceField(
         queryset=ZoneTemplate.objects.all(),
         required=False,
-        label="Zone templates",
+        label=_("Zone Templates"),
     )
     tag = TagFilterField(RecordTemplate)
 
@@ -139,27 +143,26 @@ class RecordTemplateImportForm(NetBoxModelImportForm):
     type = CSVChoiceField(
         choices=RecordTypeChoices,
         required=True,
-        help_text="Record Type",
+        label=_("Type"),
     )
     status = CSVChoiceField(
         choices=RecordStatusChoices,
         required=False,
-        help_text="Record status",
+        label=_("Status"),
     )
     ttl = forms.IntegerField(
         required=False,
-        help_text="TTL",
+        label=_("TTL"),
     )
     disable_ptr = forms.BooleanField(
         required=False,
-        label="Disable PTR",
-        help_text="Disable generation of a PTR record",
+        label=_("Disable PTR"),
     )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Assigned tenant",
+        label=_("Tenant"),
     )
 
     class Meta:
@@ -185,24 +188,36 @@ class RecordTemplateBulkEditForm(NetBoxModelBulkEditForm):
     type = forms.ChoiceField(
         choices=add_blank_choice(RecordTypeChoices),
         required=False,
+        label=_("Type"),
     )
     value = forms.CharField(
         required=False,
-        label="Value",
+        label=_("Value"),
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(RecordStatusChoices),
         required=False,
+        label=_("Status"),
     )
     ttl = forms.IntegerField(
         required=False,
-        label="TTL",
+        label=_("TTL"),
     )
     disable_ptr = forms.NullBooleanField(
-        required=False, widget=BulkEditNullBooleanSelect(), label="Disable PTR"
+        required=False,
+        widget=BulkEditNullBooleanSelect(),
+        label=_("Disable PTR"),
     )
-    description = forms.CharField(max_length=200, required=False)
-    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
+    description = forms.CharField(
+        max_length=200,
+        required=False,
+        label=_("Description"),
+    )
+    tenant = DynamicModelChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+    )
 
     fieldsets = (
         FieldSet(
@@ -213,8 +228,8 @@ class RecordTemplateBulkEditForm(NetBoxModelBulkEditForm):
             "ttl",
             "disable_ptr",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
     )
     nullable_fields = ("description", "ttl", "tenant")

--- a/netbox_dns/forms/registrar.py
+++ b/netbox_dns/forms/registrar.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -33,9 +34,9 @@ class RegistrarForm(NetBoxModelForm):
                 "whois_server",
                 "abuse_email",
                 "abuse_phone",
-                name="Registrar",
+                name=_("Registrar"),
             ),
-            FieldSet("tags", name="Tags"),
+            FieldSet("tags", name=_("Tags")),
         )
         fields = (
             "name",
@@ -54,45 +55,48 @@ class RegistrarFilterForm(NetBoxModelFilterSetForm):
     model = Registrar
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("name", "iana_id", "description", name="Attributes"),
+        FieldSet("name", "iana_id", "description", name=_("Attributes")),
         FieldSet(
             "address",
             "referral_url",
             "whois_server",
             "abuse_email",
             "abuse_phone",
-            name="Contact",
+            name=_("Contact"),
         ),
     )
 
     name = forms.CharField(
         required=False,
+        label=_("Name"),
     )
     address = forms.CharField(
         required=False,
+        label=_("Address"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     iana_id = forms.IntegerField(
         required=False,
-        label="IANA ID",
+        label=_("IANA ID"),
     )
     referral_url = forms.CharField(
         required=False,
-        label="Referral URL",
+        label=_("Referral URL"),
     )
     whois_server = forms.CharField(
         required=False,
-        label="WHOIS Server",
+        label=_("WHOIS Server"),
     )
     abuse_email = forms.CharField(
         required=False,
-        label="Abuse Email",
+        label=_("Abuse Email"),
     )
     abuse_phone = forms.CharField(
         required=False,
-        label="Abuse Phone",
+        label=_("Abuse Phone"),
     )
     tag = TagFilterField(Registrar)
 
@@ -118,31 +122,31 @@ class RegistrarBulkEditForm(NetBoxModelBulkEditForm):
 
     iana_id = forms.IntegerField(
         required=False,
-        label="IANA ID",
+        label=_("IANA ID"),
     )
     description = forms.CharField(
         required=False,
-        label="Description",
+        label=_("Description"),
     )
     address = forms.CharField(
         required=False,
-        label="Address",
+        label=_("Address"),
     )
     referral_url = forms.CharField(
         required=False,
-        label="Referral URL",
+        label=_("Referral URL"),
     )
     whois_server = forms.CharField(
         required=False,
-        label="WHOIS Server",
+        label=_("WHOIS Server"),
     )
     abuse_email = forms.CharField(
         required=False,
-        label="Abuse Email",
+        label=_("Abuse Email"),
     )
     abuse_phone = forms.CharField(
         required=False,
-        label="Abuse Phone",
+        label=_("Abuse Phone"),
     )
 
     fieldsets = (
@@ -154,7 +158,7 @@ class RegistrarBulkEditForm(NetBoxModelBulkEditForm):
             "whois_server",
             "abuse_email",
             "abuse_phone",
-            name="Attributes",
+            name=_("Attributes"),
         ),
     )
 

--- a/netbox_dns/forms/registration_contact.py
+++ b/netbox_dns/forms/registration_contact.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -37,7 +38,7 @@ class RegistrationContactForm(NetBoxModelForm):
             "fax",
             "fax_ext",
             "email",
-            name="RegistrationContact",
+            name=_("Contact"),
         ),
         FieldSet("tags", name="Tags"),
     )
@@ -68,7 +69,7 @@ class RegistrationContactFilterForm(NetBoxModelFilterSetForm):
 
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("name", "contact_id", "description", name="Attributes"),
+        FieldSet("name", "contact_id", "description", name=_("Attributes")),
         FieldSet(
             "organization",
             "street",
@@ -76,57 +77,68 @@ class RegistrationContactFilterForm(NetBoxModelFilterSetForm):
             "state_province",
             "postal_code",
             "country",
-            name="Address",
+            name=_("Address"),
         ),
-        FieldSet("phone", "phone_ext", "fax", "fax_ext", "email", name="Communication"),
+        FieldSet(
+            "phone", "phone_ext", "fax", "fax_ext", "email", name=_("Communication")
+        ),
     )
 
     name = forms.CharField(
         required=False,
+        label=_("Name"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     contact_id = forms.CharField(
         required=False,
-        label="RegistrationContact ID",
+        label=_("Contact ID"),
     )
     organization = forms.CharField(
         required=False,
+        label=_("Organization"),
     )
     street = forms.CharField(
         required=False,
+        label=_("Street"),
     )
     city = forms.CharField(
         required=False,
+        label=_("City"),
     )
     state_province = forms.CharField(
         required=False,
-        label="State/Province",
+        label=_("State/Province"),
     )
     postal_code = forms.CharField(
         required=False,
-        label="Postal Code",
+        label=_("Postal Code"),
     )
     country = forms.CharField(
         required=False,
+        label=_("Country"),
     )
     phone = forms.CharField(
         required=False,
+        label=_("Phone"),
     )
     phone_ext = forms.CharField(
         required=False,
-        label="Phone Extension",
+        label=_("Phone Extension"),
     )
     fax = forms.CharField(
         required=False,
+        label=_("Fax"),
     )
     fax_ext = forms.CharField(
         required=False,
-        label="Fax Extension",
+        label=_("Fax Extension"),
     )
     email = forms.CharField(
         required=False,
+        label=_("Email Address"),
     )
     tag = TagFilterField(RegistrationContact)
 
@@ -158,59 +170,59 @@ class RegistrationContactBulkEditForm(NetBoxModelBulkEditForm):
 
     name = forms.CharField(
         required=False,
-        label="Name",
+        label=_("Name"),
     )
     description = forms.CharField(
         required=False,
-        label="Description",
+        label=_("Description"),
     )
     organization = forms.CharField(
         required=False,
-        label="Organization",
+        label=_("Organization"),
     )
     street = forms.CharField(
         required=False,
-        label="Street",
+        label=_("Street"),
     )
     city = forms.CharField(
         required=False,
-        label="City",
+        label=_("City"),
     )
     state_province = forms.CharField(
         required=False,
-        label="State/Province",
+        label=_("State/Province"),
     )
     postal_code = forms.CharField(
         required=False,
-        label="Postal Code",
+        label=_("Postal Code"),
     )
     country = forms.CharField(
         required=False,
-        label="Country",
+        label=_("Country"),
     )
     phone = forms.CharField(
         required=False,
-        label="Phone",
+        label=_("Phone"),
     )
     phone_ext = forms.CharField(
         required=False,
-        label="Phone Extension",
+        label=_("Phone Extension"),
     )
     fax = forms.CharField(
         required=False,
-        label="Fax",
+        label=_("Fax"),
     )
     fax_ext = forms.CharField(
         required=False,
-        label="Fax Extension",
+        label=_("Fax Extension"),
     )
     email = forms.CharField(
         required=False,
-        label="Email Address",
+        label=_("Email Address"),
     )
 
     fieldsets = (
-        FieldSet("name", "description", name="Attributes"),
+        FieldSet("name", "description", name=_("Attributes")),
         FieldSet(
             "organization",
             "street",
@@ -218,7 +230,7 @@ class RegistrationContactBulkEditForm(NetBoxModelBulkEditForm):
             "state_province",
             "postal_code",
             "country",
-            name="Address",
+            name=_("Address"),
         ),
         FieldSet(
             "phone",
@@ -226,7 +238,7 @@ class RegistrationContactBulkEditForm(NetBoxModelBulkEditForm):
             "fax",
             "fax_ext",
             "email",
-            name="Communication",
+            name=_("Communication"),
         ),
     )
 

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -3,6 +3,8 @@ from django.db import transaction
 from django.conf import settings
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -125,77 +127,93 @@ class ZoneTemplateUpdateMixin:
 
 
 class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
-    nameservers = DynamicModelMultipleChoiceField(
-        queryset=NameServer.objects.all(),
-        required=False,
-    )
-    default_ttl = forms.IntegerField(
-        required=False,
-        label="Default TTL",
-        help_text="Default TTL for new records in this zone",
-        validators=[MinValueValidator(1)],
-    )
-    soa_ttl = forms.IntegerField(
+    name = forms.CharField(
         required=True,
-        label="SOA TTL",
-        help_text="TTL for the SOA record of the zone",
-        validators=[MinValueValidator(1)],
-    )
-    soa_rname = forms.CharField(
-        required=True,
-        label="SOA RName",
-        help_text="Mailbox of the zone's administrator",
-    )
-    soa_serial_auto = forms.BooleanField(
-        required=False,
-        label="Generate SOA Serial",
-        help_text="Automatically generate the SOA Serial",
-    )
-    soa_serial = forms.IntegerField(
-        required=False,
-        label="SOA Serial",
-        help_text="Serial number of the current zone data version",
-        validators=[MinValueValidator(1)],
-    )
-    soa_refresh = forms.IntegerField(
-        required=True,
-        label="SOA Refresh",
-        help_text="Refresh interval for secondary name servers",
-        validators=[MinValueValidator(1)],
-    )
-    soa_retry = forms.IntegerField(
-        required=True,
-        label="SOA Retry",
-        help_text="Retry interval for secondary name servers",
-        validators=[MinValueValidator(1)],
-    )
-    soa_expire = forms.IntegerField(
-        required=True,
-        label="SOA Expire",
-        help_text="Expire time after which the zone is considered unavailable",
-        validators=[MinValueValidator(1)],
-    )
-    soa_minimum = forms.IntegerField(
-        required=True,
-        label="SOA Minimum TTL",
-        help_text="Minimum TTL for negative results, e.g. NXRRSET",
-        validators=[MinValueValidator(1)],
-    )
-    rfc2317_prefix = RFC2317NetworkFormField(
-        label="RFC2317 Prefix",
-        help_text="IPv4 network prefix with a mask length of at least 25 bits",
-        validators=[validate_ipv4, validate_prefix, validate_rfc2317],
-        required=False,
-    )
-    rfc2317_parent_managed = forms.BooleanField(
-        label="RFC2317 Parent Managed",
-        help_text="IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS",
-        required=False,
+        label=_("Name"),
     )
     template = DynamicModelChoiceField(
         queryset=ZoneTemplate.objects.all(),
         required=False,
-        label="Template",
+        label=_("Template"),
+    )
+    status = forms.ChoiceField(
+        choices=ZoneStatusChoices,
+        required=False,
+        label=_("Status"),
+    )
+    nameservers = DynamicModelMultipleChoiceField(
+        queryset=NameServer.objects.all(),
+        required=False,
+        label=_("Nameservers"),
+    )
+    default_ttl = forms.IntegerField(
+        required=False,
+        help_text=_("Default TTL for new records in this zone"),
+        validators=[MinValueValidator(1)],
+        label=_("Default TTL"),
+    )
+    description = forms.CharField(
+        required=False,
+        label=_("Description"),
+    )
+    soa_ttl = forms.IntegerField(
+        required=True,
+        help_text=_("TTL for the SOA record of the zone"),
+        validators=[MinValueValidator(1)],
+        label=_("SOA TTL"),
+    )
+    soa_rname = forms.CharField(
+        required=True,
+        help_text=_("Mailbox of the zone's administrator"),
+        label=_("SOA RName"),
+    )
+    soa_refresh = forms.IntegerField(
+        required=True,
+        help_text=_("Refresh interval for secondary nameservers"),
+        validators=[MinValueValidator(1)],
+        label=_("SOA Refresh"),
+    )
+    soa_retry = forms.IntegerField(
+        required=True,
+        help_text=_("Retry interval for secondary nameservers"),
+        validators=[MinValueValidator(1)],
+        label=_("SOA Retry"),
+    )
+    soa_expire = forms.IntegerField(
+        required=True,
+        validators=[MinValueValidator(1)],
+        help_text=_("Expire time after which the zone is considered unavailable"),
+        label=_("SOA Expire"),
+    )
+    soa_minimum = forms.IntegerField(
+        required=True,
+        help_text=_("Minimum TTL for negative results, e.g. NXRRSET"),
+        validators=[MinValueValidator(1)],
+        label=_("SOA Minimum TTL"),
+    )
+    soa_serial_auto = forms.BooleanField(
+        required=False,
+        help_text=_("Automatically generate the SOA serial number"),
+        label=_("Generate SOA Serial"),
+    )
+    soa_serial = forms.IntegerField(
+        required=False,
+        validators=[MinValueValidator(1)],
+        label=_("SOA Serial"),
+    )
+
+    rfc2317_prefix = RFC2317NetworkFormField(
+        required=False,
+        validators=[validate_ipv4, validate_prefix, validate_rfc2317],
+        help_text=_("RFC2317 IPv4 prefix with a length of at least 25 bits"),
+        label=_("RFC2317 Prefix"),
+    )
+    rfc2317_parent_managed = forms.BooleanField(
+        required=False,
+        help_text=_(
+            "IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS"
+        ),
+        label=_("RFC2317 Parent Managed"),
     )
 
     fieldsets = (
@@ -207,7 +225,7 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
             "nameservers",
             "default_ttl",
             "description",
-            name="Zone",
+            name=_("Zone"),
         ),
         FieldSet(
             "soa_ttl",
@@ -219,12 +237,12 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
             "soa_minimum",
             "soa_serial_auto",
             "soa_serial",
-            name="SOA",
+            name=_("SOA"),
         ),
         FieldSet(
             "rfc2317_prefix",
             "rfc2317_parent_managed",
-            name="RFC 2317",
+            name=_("RFC2317"),
         ),
         FieldSet(
             "registrar",
@@ -233,10 +251,10 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
             "admin_c",
             "tech_c",
             "billing_c",
-            name="Domain Registration",
+            name=_("Domain Registration"),
         ),
-        FieldSet("tags", name="Tags"),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tags", name=_("Tags")),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
     )
 
     def __init__(self, *args, **kwargs):
@@ -322,8 +340,8 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
             "tenant",
         )
         help_texts = {
-            "view": "View the zone belongs to",
-            "soa_mname": "Primary name server for the zone",
+            "view": _("View the zone belongs to"),
+            "soa_mname": _("Primary nameserver for the zone"),
         }
 
 
@@ -337,19 +355,19 @@ class ZoneFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
             "name",
             "nameserver_id",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
         FieldSet(
             "soa_mname_id",
             "soa_rname",
             "soa_serial_auto",
-            name="SOA",
+            name=_("SOA"),
         ),
         FieldSet(
             "rfc2317_prefix",
             "rfc2317_parent_managed",
             "rfc2317_parent_zone_id",
-            name="RFC2317",
+            name=_("RFC2317"),
         ),
         FieldSet(
             "registrar_id",
@@ -358,87 +376,90 @@ class ZoneFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
             "admin_c_id",
             "tech_c_id",
             "billing_c_id",
-            name="Registration",
+            name=_("Registration"),
         ),
-        FieldSet("tenant_group_id", "tenant_id", name="Tenancy"),
+        FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
     )
 
     view_id = DynamicModelMultipleChoiceField(
         queryset=View.objects.all(),
         required=False,
-        label="View",
+        label=_p("DNS", "View"),
     )
     status = forms.MultipleChoiceField(
         choices=ZoneStatusChoices,
         required=False,
+        label=_("Status"),
     )
     name = forms.CharField(
         required=False,
+        label=_("Name"),
     )
     nameserver_id = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
-        label="Nameservers",
+        label=_("Nameservers"),
     )
     description = forms.CharField(
         required=False,
+        label=_("Description"),
     )
     soa_mname_id = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
-        label="MName",
         required=False,
+        label=_("MName"),
     )
     soa_rname = forms.CharField(
         required=False,
-        label="RName",
+        label=_("RName"),
     )
     soa_serial_auto = forms.NullBooleanField(
         required=False,
-        label="Generate Serial",
         widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        label=_("Generate SOA Serial"),
     )
     rfc2317_prefix = RFC2317NetworkFormField(
         required=False,
-        label="Prefix",
+        label=_("Prefix"),
     )
     rfc2317_parent_managed = forms.NullBooleanField(
         required=False,
-        label="Parent Managed",
         widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
+        label=_("Parent Managed"),
     )
     rfc2317_parent_zone_id = DynamicModelMultipleChoiceField(
         queryset=Zone.objects.all(),
         required=False,
-        label="Parent Zone",
+        label=_("Parent Zone"),
     )
     registrar_id = DynamicModelMultipleChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
-        label="Registrar",
+        label=_("Registrar"),
     )
     registry_domain_id = forms.CharField(
         required=False,
-        label="Registry Domain ID",
+        label=_("Registry Domain ID"),
     )
     registrant_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Registrant",
+        label=_("Registrant"),
     )
     admin_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Admin-C",
+        label=_("Administrative Contact"),
     )
     tech_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Tech-C",
+        label=_("Technical Contact"),
     )
     billing_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Billing-C",
+        label=_("Billing Contact"),
     )
     tag = TagFilterField(Zone)
 
@@ -448,136 +469,153 @@ class ZoneImportForm(ZoneTemplateUpdateMixin, NetBoxModelImportForm):
         queryset=View.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="View the zone belongs to",
         error_messages={
-            "invalid_choice": "View not found.",
+            "invalid_choice": _("View not found."),
         },
+        label=_("View"),
     )
     status = CSVChoiceField(
         choices=ZoneStatusChoices,
         required=False,
-        help_text="Zone status",
+        label=_("Status"),
     )
     nameservers = CSVModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Name servers for the zone",
+        label=_("Nameservers"),
     )
     default_ttl = forms.IntegerField(
         required=False,
-        help_text="Default TTL",
+        label=_("Default TTL"),
     )
     soa_ttl = forms.IntegerField(
         required=False,
-        help_text="TTL for the SOA record of the zone",
+        help_text=_("TTL for the SOA record of the zone"),
+        label=_("SOA TTL"),
     )
     soa_mname = CSVModelChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="Primary name server for the zone",
         error_messages={
-            "invalid_choice": "Nameserver not found.",
+            "invalid_choice": _("Nameserver not found."),
         },
+        help_text=_("Primary nameserver for the zone"),
+        label=_("SOA MName"),
     )
     soa_rname = forms.CharField(
         required=False,
-        help_text="Mailbox of the zone's administrator",
+        help_text=_("Mailbox of the zone's administrator"),
+        label=_("SOA RName"),
     )
     soa_serial_auto = forms.BooleanField(
         required=False,
-        help_text="Generate the SOA serial",
+        label=_("Generate SOA Serial"),
     )
     soa_serial = forms.IntegerField(
         required=False,
-        help_text="Serial number of the current zone data version",
+        label=_("SOA Serial"),
     )
     soa_refresh = forms.IntegerField(
         required=False,
-        help_text="Refresh interval for secondary name servers",
+        help_text=_("Refresh interval for secondary nameservers"),
+        label=_("SOA Refresh"),
     )
     soa_retry = forms.IntegerField(
         required=False,
-        help_text="Retry interval for secondary name servers",
+        help_text=_("Retry interval for secondary nameservers"),
+        label=_("SOA Retry"),
     )
     soa_expire = forms.IntegerField(
         required=False,
-        help_text="Expire time after which the zone is considered unavailable",
+        help_text=_("Expire time after which the zone is considered unavailable"),
+        label=_("SOA Expire"),
     )
     soa_minimum = forms.IntegerField(
         required=False,
-        help_text="Minimum TTL for negative results, e.g. NXRRSET",
+        help_text=_("Minimum TTL for negative results, e.g. NXRRSET, NXDOMAIN"),
+        label=_("SOA Minimum TTL"),
     )
     rfc2317_prefix = RFC2317NetworkFormField(
         required=False,
-        help_text="RFC2317 IPv4 prefix with a length of at least 25 bits",
+        help_text=_("RFC2317 IPv4 prefix with a length of at least 25 bits"),
+        label=_("RFC2317 Prefix"),
     )
     rfc2317_parent_managed = forms.BooleanField(
         required=False,
-        label="RFC2317 Parent Managed",
-        help_text="IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS",
+        help_text=_(
+            "IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS"
+        ),
+        label=_("RFC2317 Parent Managed"),
     )
     registrar = CSVModelChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="Registrar the domain is registered with",
         error_messages={
-            "invalid_choice": "Registrar not found.",
+            "invalid_choice": _("Registrar not found."),
         },
+        help_text=_("Registrar the domain is registered with"),
+        label=_("Registrar"),
     )
     registry_domain_id = forms.CharField(
         required=False,
-        help_text="Domain ID assigned by the registry",
+        help_text=_("Domain ID assigned by the registry"),
+        label=_("Registry Domain ID"),
     )
     registrant = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Owner of the domain",
         error_messages={
-            "invalid_choice": "Registrant contact ID not found",
+            "invalid_choice": _("Registrant contact ID not found"),
         },
+        help_text=_("Owner of the domain"),
+        label=_("Registrant"),
     )
     admin_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Administrative contact for the domain",
+        help_text=_("Administrative contact for the domain"),
         error_messages={
-            "invalid_choice": "Administrative contact ID not found",
+            "invalid_choice": _("Administrative contact ID not found"),
         },
+        label=_("Administrative Contact"),
     )
     tech_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Technical contact for the domain",
+        help_text=_("Technical contact for the domain"),
         error_messages={
-            "invalid_choice": "Technical contact ID not found",
+            "invalid_choice": _("Technical contact ID not found"),
         },
+        label=_("Technical Contact"),
     )
     billing_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Billing contact for the domain",
+        help_text=_("Billing contact for the domain"),
         error_messages={
-            "invalid_choice": "Billing contact ID not found",
+            "invalid_choice": _("Billing contact ID not found"),
         },
+        label=_("Billing Contact"),
     )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="Assigned tenant",
+        help_text=_("Assigned tenant"),
+        label=_("Tenant"),
     )
     template = CSVModelChoiceField(
         queryset=ZoneTemplate.objects.all(),
         required=False,
         to_field_name="name",
-        label="Template",
+        label=_("Template"),
     )
 
     class Meta:
@@ -638,108 +676,119 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
     view = DynamicModelChoiceField(
         queryset=View.objects.all(),
         required=False,
-        label="View",
+        label=_p("DNS", "View"),
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(ZoneStatusChoices),
         required=False,
+        label=_("Status"),
     )
     nameservers = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
+        label=_("Nameservers"),
     )
     default_ttl = forms.IntegerField(
         required=False,
-        label="Default TTL",
         validators=[MinValueValidator(1)],
+        label=_("Default TTL"),
     )
-    description = forms.CharField(max_length=200, required=False)
+    description = forms.CharField(
+        max_length=200,
+        required=False,
+        label=_("Description"),
+    )
     soa_ttl = forms.IntegerField(
         required=False,
-        label="SOA TTL",
         validators=[MinValueValidator(1)],
+        label=_("SOA TTL"),
     )
     soa_mname = DynamicModelChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
-        label="SOA Primary Nameserver",
+        label=_("SOA MName"),
     )
     soa_rname = forms.CharField(
         required=False,
-        label="SOA RName",
+        label=_("SOA RName"),
     )
     soa_serial_auto = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect(),
-        label="Generate SOA Serial",
+        label=_("Generate SOA Serial"),
     )
     soa_serial = forms.IntegerField(
         required=False,
-        label="SOA Serial",
         validators=[MinValueValidator(1), MaxValueValidator(4294967295)],
+        label=_("SOA Serial"),
     )
     soa_refresh = forms.IntegerField(
         required=False,
-        label="SOA Refresh",
         validators=[MinValueValidator(1)],
+        label=_("SOA Refresh"),
     )
     soa_retry = forms.IntegerField(
         required=False,
-        label="SOA Retry",
         validators=[MinValueValidator(1)],
+        label=_("SOA Retry"),
     )
     soa_expire = forms.IntegerField(
         required=False,
-        label="SOA Expire",
         validators=[MinValueValidator(1)],
+        label=_("SOA Expire"),
     )
     soa_minimum = forms.IntegerField(
         required=False,
-        label="SOA Minimum TTL",
         validators=[MinValueValidator(1)],
+        label=_("SOA Minimum TTL"),
     )
     rfc2317_prefix = RFC2317NetworkFormField(
         required=False,
-        label="RFC2317 Prefix",
-        help_text="IPv4 network prefix with a mask length of at least 25 bits",
         validators=[validate_ipv4, validate_prefix, validate_rfc2317],
+        help_text=_("RFC2317 IPv4 prefix with a length of at least 25 bits"),
+        label=_("RFC2317 Prefix"),
     )
     rfc2317_parent_managed = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect(),
-        label="RFC2317 Parent Managed",
-        help_text="IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS",
+        help_text=_(
+            "IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in NetBox DNS"
+        ),
+        label=_("RFC2317 Parent Managed"),
     )
     registrar = DynamicModelChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
+        label=_("Registrar"),
     )
     registry_domain_id = forms.CharField(
         required=False,
-        label="Registry Domain ID",
+        label=_("Registry Domain ID"),
     )
     registrant = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
+        label=_("Registrant"),
     )
     admin_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Administrative Contact",
+        label=_("Administrative Contact"),
     )
     tech_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Technical Contact",
+        label=_("Technical Contact"),
     )
     billing_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Billing Contact",
+        label=_("Billing Contact"),
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
+        label=_("Tenant"),
     )
 
     model = Zone
@@ -751,7 +800,7 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
             "nameservers",
             "default_ttl",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
         FieldSet(
             "soa_ttl",
@@ -763,12 +812,12 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
             "soa_minimum",
             "soa_serial_auto",
             "soa_serial",
-            name="SOA",
+            name=_("SOA"),
         ),
         FieldSet(
             "rfc2317_prefix",
             "rfc2317_parent_managed",
-            name="RFC 2317",
+            name=_("RFC2317"),
         ),
         FieldSet(
             "registrar",
@@ -777,9 +826,9 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
             "admin_c",
             "tech_c",
             "billing_c",
-            name="Domain Registration",
+            name=_("Domain Registration"),
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
     )
 
     nullable_fields = (

--- a/netbox_dns/forms/zone_template.py
+++ b/netbox_dns/forms/zone_template.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from netbox.forms import (
     NetBoxModelBulkEditForm,
@@ -45,18 +46,18 @@ class ZoneTemplateForm(TenancyForm, NetBoxModelForm):
     )
 
     fieldsets = (
-        FieldSet("name", "description", "nameservers", name="Zone Template"),
-        FieldSet("record_templates", name="Record Templates"),
+        FieldSet("name", "description", "nameservers", name=_("Zone Template")),
+        FieldSet("record_templates", name=_("Record Templates")),
         FieldSet(
             "registrar",
             "registrant",
             "admin_c",
             "tech_c",
             "billing_c",
-            name="Domain Registration",
+            name=_("Domain Registration"),
         ),
-        FieldSet("tags", name="Tags"),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tags", name=_("Tags")),
+        FieldSet("tenant_group", "tenant", name=_("Tenancy")),
     )
 
     class Meta:
@@ -81,32 +82,32 @@ class ZoneTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = ZoneTemplate
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
-        FieldSet("name", "nameserver_id", "description", name="Attributes"),
-        FieldSet("record_template_id", name="Record Templates"),
+        FieldSet("name", "nameserver_id", "description", name=_("Attributes")),
+        FieldSet("record_template_id", name=_("Record Templates")),
         FieldSet(
             "registrar_id",
             "registrant_id",
             "admin_c_id",
             "tech_c_id",
             "billing_c_id",
-            name="Registration",
+            name=_("Registration"),
         ),
-        FieldSet("tenant_group_id", "tenant_id", name="Tenancy"),
+        FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
     )
 
     name = forms.CharField(
         required=False,
-        label="Template name",
+        label=_("Template Name"),
     )
     nameserver_id = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
-        label="Nameservers",
+        label=_("Nameservers"),
     )
     record_template_id = DynamicModelMultipleChoiceField(
         queryset=RecordTemplate.objects.all(),
         required=False,
-        label="Record templates",
+        label=_("Record Templates"),
     )
     description = forms.CharField(
         required=False,
@@ -114,27 +115,27 @@ class ZoneTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     registrar_id = DynamicModelMultipleChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
-        label="Registrar",
+        label=_("Registrar"),
     )
     registrant_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Registrant",
+        label=_("Registrant"),
     )
     admin_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Admin-C",
+        label=_("Administrative Contact"),
     )
     tech_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Tech-C",
+        label=_("Technical Contact"),
     )
     billing_c_id = DynamicModelMultipleChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Billing-C",
+        label=_("Billing Contact"),
     )
     tag = TagFilterField(ZoneTemplate)
 
@@ -144,64 +145,64 @@ class ZoneTemplateImportForm(NetBoxModelImportForm):
         queryset=NameServer.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Name servers for the zone template",
+        label=_("Nameservers"),
     )
     record_templates = CSVModelMultipleChoiceField(
         queryset=RecordTemplate.objects.all(),
         to_field_name="name",
         required=False,
-        help_text="Record templates used by this zone template",
+        label=_("Record Remplates"),
     )
     registrar = CSVModelChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="Registrar the domain is registered with",
         error_messages={
-            "invalid_choice": "Registrar not found.",
+            "invalid_choice": _("Registrar not found."),
         },
+        label=_("Registrar"),
     )
     registrant = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Owner of the domain",
         error_messages={
-            "invalid_choice": "Registrant contact ID not found",
+            "invalid_choice": _("Registrant contact ID not found"),
         },
+        label=_("Registrant"),
     )
     admin_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Administrative contact for the domain",
         error_messages={
-            "invalid_choice": "Administrative contact ID not found",
+            "invalid_choice": _("Administrative contact ID not found"),
         },
+        label=_("Administrative Contact"),
     )
     tech_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Technical contact for the domain",
         error_messages={
-            "invalid_choice": "Technical contact ID not found",
+            "invalid_choice": _("Technical contact ID not found"),
         },
+        label=_("Technical Contact"),
     )
     billing_c = CSVModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
         to_field_name="contact_id",
-        help_text="Billing contact for the domain",
         error_messages={
-            "invalid_choice": "Billing contact ID not found",
+            "invalid_choice": _("Billing contact ID not found"),
         },
+        label=_("Billing Contact"),
     )
     tenant = CSVModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
         to_field_name="name",
-        help_text="Assigned tenant",
+        label=_("Tenant"),
     )
 
     class Meta:
@@ -226,42 +227,44 @@ class ZoneTemplateBulkEditForm(NetBoxModelBulkEditForm):
     nameservers = DynamicModelMultipleChoiceField(
         queryset=NameServer.objects.all(),
         required=False,
+        label=_("Nameservers"),
     )
     record_templates = DynamicModelMultipleChoiceField(
         queryset=RecordTemplate.objects.all(),
         required=False,
+        label=_("Record Templates"),
     )
     description = forms.CharField(max_length=200, required=False)
     registrar = DynamicModelChoiceField(
         queryset=Registrar.objects.all(),
         required=False,
+        label=_("Registrar"),
     )
     registrant = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
+        label=_("Registrant"),
     )
     admin_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Administrative Contact",
+        label=_("Administrative Contact"),
     )
     tech_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Technical Contact",
+        label=_("Technical Contact"),
     )
     billing_c = DynamicModelChoiceField(
         queryset=RegistrationContact.objects.all(),
         required=False,
-        label="Billing Contact",
+        label=_("Billing Contact"),
     )
-    tenant = CSVModelChoiceField(
+    tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
-        to_field_name="name",
-        help_text="Assigned tenant",
+        label=_("Tenant"),
     )
-    tenant = DynamicModelChoiceField(queryset=Tenant.objects.all(), required=False)
 
     model = ZoneTemplate
 
@@ -269,11 +272,11 @@ class ZoneTemplateBulkEditForm(NetBoxModelBulkEditForm):
         FieldSet(
             "nameservers",
             "description",
-            name="Attributes",
+            name=_("Attributes"),
         ),
         FieldSet(
             "record_templates",
-            name="Record Templates",
+            name=_("Record Templates"),
         ),
         FieldSet(
             "registrar",
@@ -281,9 +284,9 @@ class ZoneTemplateBulkEditForm(NetBoxModelBulkEditForm):
             "admin_c",
             "tech_c",
             "billing_c",
-            name="Domain Registration",
+            name=_("Domain Registration"),
         ),
-        FieldSet("tenant_group", "tenant", name="Tenancy"),
+        FieldSet("tenant", name=_("Tenancy")),
     )
 
     nullable_fields = (

--- a/netbox_dns/locale/de/LC_MESSAGES/django.po
+++ b/netbox_dns/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,1354 @@
+# German translations for the NetBox DNS plugin
+# Copyright (C) 2024
+# This file is distributed under the same license as the NetBox DNS plugin.
+# Peter Eckel <pete@netbox-dns.org>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.1.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-30 15:17+0000\n"
+"PO-Revision-Date: 2024-09-29 12:06+0000\n"
+"Last-Translator: Peter Eckel <pete@netbox-dns.org>\n"
+"Language-Team: LANGUAGE  <language@netbox-dns.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: __init__.py:14
+msgid "NetBox DNS"
+msgstr "NetBox DNS"
+
+#: __init__.py:15
+msgid "NetBox plugin for DNS data"
+msgstr "NetBox-Plugin für DNS-Daten"
+
+#: api/nested_serializers.py:41 api/serializers_/zone.py:31 forms/zone.py:343
+msgid "View the zone belongs to"
+msgstr "Ansicht, in der sich die Zone befindet"
+
+#: api/nested_serializers.py:86 api/serializers_/record.py:37
+msgid "Zone the record belongs to"
+msgstr "Zone, in der sich der Datensatz befindet"
+
+#: api/serializers_/nameserver.py:24
+msgid "Zones served by the authoritative nameserver"
+msgstr "Zonen, für die der Nameserver autoritativ ist"
+
+#: api/serializers_/record.py:25
+msgid "PTR record generated from an address"
+msgstr "Für eine Adresse erzeugter PTR-Datensatz"
+
+#: api/serializers_/record.py:32
+msgid "Address record defining the PTR"
+msgstr "Adress-Datensatz, der der PTR-Datensatz definiert"
+
+#: api/serializers_/record.py:49
+msgid "IPAddress linked to the record"
+msgstr "IP-Adresse, die mit dem Datensatz verbunden ist"
+
+#: api/serializers_/record_template.py:24
+msgid "Zone templates using the record template"
+msgstr "Zonenvorlagen, die die Datensatzvorlage verwenden"
+
+#: api/serializers_/view.py:26
+msgid "IPAM Prefixes assigned to the View"
+msgstr "Der Ansicht zugeordnete IPAM-Prefixe"
+
+#: api/serializers_/zone.py:38 api/serializers_/zone_template.py:27
+msgid "Nameservers for the zone"
+msgstr "Nameserver für die Zone"
+
+#: api/serializers_/zone.py:45 forms/zone.py:344 forms/zone.py:504
+msgid "Primary nameserver for the zone"
+msgstr "Primärer Nameserver für die Zone"
+
+#: api/serializers_/zone.py:51
+msgid "RFC2317 parent zone of the zone"
+msgstr "Übergeordnete Zone der RFC2317-Zone"
+
+#: api/serializers_/zone.py:57
+msgid "RFC2317 child zones of the zone"
+msgstr "Untergeordnete RFC2317-Zonen der Zone"
+
+#: api/serializers_/zone.py:64 api/serializers_/zone_template.py:40
+#: forms/zone.py:559 models/zone.py:189 models/zone_template.py:50
+msgid "Registrar the domain is registered with"
+msgstr "Registrar, bei dem die Domäne registriert ist"
+
+#: api/serializers_/zone.py:71 api/serializers_/zone_template.py:47
+#: models/zone.py:204
+#, fuzzy
+msgid "Registrant of the domain"
+msgstr "Inhaber der Domäne"
+
+#: api/serializers_/zone.py:78 api/serializers_/zone_template.py:54
+#: forms/zone.py:581 models/zone.py:213 models/zone_template.py:68
+msgid "Administrative contact for the domain"
+msgstr "Administrativer Ansprechpartners für die Domäne"
+
+#: api/serializers_/zone.py:85 api/serializers_/zone_template.py:61
+#: forms/zone.py:591 models/zone.py:222 models/zone_template.py:77
+msgid "Technical contact for the domain"
+msgstr "Technischer Ansprechpartners für die Domäne"
+
+#: api/serializers_/zone.py:92 api/serializers_/zone_template.py:68
+#: forms/zone.py:601 models/zone.py:231 models/zone_template.py:86
+msgid "Billing contact for the domain"
+msgstr "Kaufmännischer Ansprechpartner für die Domäne"
+
+#: api/serializers_/zone.py:99
+msgid "Template to apply to the zone"
+msgstr "Zonenvorlage, die für die Zone verwendet werden soll"
+
+#: api/serializers_/zone_template.py:33
+msgid "Record templates assigned to the zone template"
+msgstr "Der Zonenvorlage zugewiesene Datensatzvorlagen"
+
+#: api/views.py:84
+msgid "'managed' is True, refusing create"
+msgstr "Der Datensatz ist auf 'verwaltet' gesetztt, Erstellung gesperrt"
+
+#: api/views.py:92
+#, python-brace-format
+msgid "{object} is managed, refusing deletion"
+msgstr "Das Objekt {object} ist verwaltet und kann nicht gelöscht werden"
+
+#: api/views.py:101
+#, python-brace-format
+msgid "{object} is managed, refusing update"
+msgstr "Das Objekt {object} ist verwaltet und kann nicht geändert werden"
+
+#: api/views.py:106
+#, python-brace-format
+msgid "{object} is unmanaged, refusing update to managed"
+msgstr ""
+"Das Objekt {object} ist nicht verwaltet, eine Änderung auf 'verwaltet' ist "
+"nicht möglich"
+
+#: choices/record.py:49 choices/zone.py:18 tables/record.py:60
+msgid "Active"
+msgstr "Aktiv"
+
+#: choices/record.py:50
+msgid "Inactive"
+msgstr "Inaktiv"
+
+#: choices/zone.py:19
+msgid "Reserved"
+msgstr "Reserviert"
+
+#: choices/zone.py:20
+msgid "Deprecated"
+msgstr "Veraltet"
+
+#: choices/zone.py:21
+msgid "Parked"
+msgstr "Geparkt"
+
+#: fields/address.py:32
+msgid "IPv4/v6 address"
+msgstr "IPv4/v6-Adresse"
+
+#: fields/network.py:80
+msgid "IPv4/v6 network associated with a reverse lookup zone"
+msgstr "IPv4/v6-Netz ist mit einer Reverse-Lookup-Zone verbunden"
+
+#: fields/rfc2317.py:12
+msgid "RFC2317 requires an IPv4 prefix with a length of at least 25 bits."
+msgstr ""
+"RFC2317 erfordert ein IPv4-Prefix mit einer Länge von mindestens 25 Bit."
+
+#: fields/rfc2317.py:34
+msgid "Please specify the prefix length"
+msgstr "Bitte geben Sie die Länge des Prefixes an"
+
+#: fields/rfc2317.py:48
+msgid "PostgreSQL CIDR field for an RFC2317 prefix"
+msgstr "PostgreSQL CIDR-Feld für ein RFC2317-Prefix"
+
+#: filtersets/nameserver.py:19 forms/nameserver.py:67 models/zone.py:276
+#: navigation.py:31 views/nameserver.py:96 views/registrar.py:80
+#: views/registration_contact.py:83 views/view.py:100
+msgid "Zones"
+msgstr "Zonen"
+
+#: filtersets/nameserver.py:24 forms/nameserver.py:72 views/nameserver.py:116
+msgid "SOA Zones"
+msgstr "SOA-Zonen"
+
+#: filtersets/record.py:32
+msgid "Parent Zone ID"
+msgstr "ID der übergeordneten Zone"
+
+#: filtersets/record.py:38 forms/zone.py:433 templates/netbox_dns/zone.html:23
+#: templates/netbox_dns/zone.html:161
+msgid "Parent Zone"
+msgstr "Übergeordnete Zone"
+
+#: filtersets/record.py:43
+msgid "ID of the View the Parent Zone belongs to"
+msgstr "ID der Ansicht, zu der die übergeprdnete Zone gehört"
+
+#: filtersets/record.py:49
+msgid "View the Parent Zone belongs to"
+msgstr "Ansicht, zu der die übergeordnete Zone gehört"
+
+#: filtersets/record.py:55 tables/record.py:104
+#: templates/netbox_dns/record.html:103
+msgid "Address Record"
+msgstr "Adress-Datensatz"
+
+#: filtersets/record.py:61 filtersets/record.py:67
+msgid "Pointer Record"
+msgstr "Zeiger-Datensatz"
+
+#: filtersets/record.py:73 models/record.py:202 tables/record.py:108
+#: templates/netbox_dns/record.html:108 templates/netbox_dns/record.html:115
+msgid "IPAM IP Address"
+msgstr "IPAM-IP-Adresse"
+
+#: filtersets/record.py:77
+msgid "IP Address"
+msgstr "IP-Adresse"
+
+#: filtersets/record_template.py:26 forms/zone_template.py:49
+#: models/zone_template.py:113 templates/netbox_dns/recordtemplate.html:84
+#: templates/netbox_dns/zonetemplate.html:12
+msgid "Zone Template"
+msgstr "Zonenvorlage"
+
+#: filtersets/record_template.py:32
+msgid "Zone Template ID"
+msgstr "ID der Zonenvorlage"
+
+#: filtersets/view.py:21
+msgid "Prefix ID"
+msgstr "ID des Prefixes"
+
+#: filtersets/view.py:27 forms/view.py:198 forms/zone.py:423
+#: templates/netbox_dns/zone.html:152
+msgid "Prefix"
+msgstr "Prefix"
+
+#: filtersets/zone.py:25
+msgid "View ID"
+msgstr "ID der Ansicht"
+
+#: filtersets/zone.py:38
+msgid "Nameserver IDs"
+msgstr "IDs der Nameserver"
+
+#: filtersets/zone.py:45 forms/zone.py:147 forms/zone.py:401 forms/zone.py:486
+#: forms/zone.py:689 forms/zone_template.py:105 forms/zone_template.py:148
+#: forms/zone_template.py:230 models/nameserver.py:57
+#: models/zone_template.py:27 navigation.py:51
+#: templates/netbox_dns/zone.html:51 templates/netbox_dns/zonetemplate.html:34
+msgid "Nameservers"
+msgstr "Nameserver"
+
+#: filtersets/zone.py:51 filtersets/zone_template.py:38
+msgid "Nameservers ID"
+msgstr "IDs der Nameserver"
+
+#: filtersets/zone.py:57 filtersets/zone_template.py:44 forms/nameserver.py:47
+#: models/nameserver.py:56 models/zone.py:103
+#: templates/netbox_dns/nameserver.html:8
+msgid "Nameserver"
+msgstr "Nameserver"
+
+#: filtersets/zone.py:61
+msgid "SOA MName ID"
+msgstr "SOA MName-ID"
+
+#: filtersets/zone.py:67 forms/zone.py:505 forms/zone.py:709 models/zone.py:120
+#: tables/zone.py:28
+msgid "SOA MName"
+msgstr ""
+
+#: filtersets/zone.py:71 models/zone.py:173
+msgid "ARPA Network"
+msgstr "ARPA-Netz"
+
+#: filtersets/zone.py:75 forms/zone.py:209 forms/zone.py:543 forms/zone.py:749
+#: models/zone.py:236 tables/zone.py:41
+msgid "RFC2317 Prefix"
+msgstr "RFC2317-Prefix"
+
+#: filtersets/zone.py:81 filtersets/zone.py:87 models/zone.py:247
+#: tables/zone.py:44
+msgid "RFC2317 Parent Zone"
+msgstr "Übergeordnete RF2317-Zone"
+
+#: filtersets/zone.py:97 filtersets/zone_template.py:54 forms/registrar.py:37
+#: forms/zone.py:438 forms/zone.py:560 forms/zone.py:762
+#: forms/zone_template.py:118 forms/zone_template.py:163
+#: forms/zone_template.py:241 models/registrar.py:66 models/zone.py:188
+#: models/zone_template.py:46 tables/zone.py:48 tables/zone_template.py:25
+#: templates/netbox_dns/registrar.html:8
+#: templates/netbox_dns/zone/registration.html:10
+#: templates/netbox_dns/zonetemplate.html:58
+msgid "Registrar"
+msgstr "Registrar"
+
+#: filtersets/zone.py:101 filtersets/zone_template.py:58
+msgid "Registrant ID"
+msgstr "ID des Dommänen-Inhabers"
+
+#: filtersets/zone.py:107 filtersets/zone_template.py:64 forms/zone.py:447
+#: forms/zone.py:575 forms/zone.py:771 forms/zone_template.py:123
+#: forms/zone_template.py:172 forms/zone_template.py:246 models/zone.py:201
+#: models/zone_template.py:55 tables/zone.py:52 tables/zone_template.py:29
+#: templates/netbox_dns/zone/registration.html:18
+#: templates/netbox_dns/zonetemplate.html:62
+msgid "Registrant"
+msgstr "Domänen-Inhaber"
+
+#: filtersets/zone.py:111 filtersets/zone_template.py:68
+msgid "Administrative Contact ID"
+msgstr "ID des administrativen Ansprechpartners"
+
+#: filtersets/zone.py:117 filtersets/zone_template.py:74 forms/zone.py:452
+#: forms/zone.py:585 forms/zone.py:776 forms/zone_template.py:128
+#: forms/zone_template.py:181 forms/zone_template.py:251
+#: models/zone_template.py:64 tables/zone.py:56 tables/zone_template.py:33
+#: templates/netbox_dns/zone/registration.html:22
+#: templates/netbox_dns/zonetemplate.html:66
+msgid "Administrative Contact"
+msgstr "Adminstrativer Ansprechpartner"
+
+#: filtersets/zone.py:121 filtersets/zone_template.py:78
+msgid "Technical Contact ID"
+msgstr "ID des technischen Ansprechpartners"
+
+#: filtersets/zone.py:127 filtersets/zone_template.py:84 forms/zone.py:457
+#: forms/zone.py:595 forms/zone.py:781 forms/zone_template.py:133
+#: forms/zone_template.py:190 forms/zone_template.py:256 models/zone.py:218
+#: models/zone_template.py:73 tables/zone.py:60 tables/zone_template.py:37
+#: templates/netbox_dns/zone/registration.html:26
+#: templates/netbox_dns/zonetemplate.html:70
+msgid "Technical Contact"
+msgstr "Technischer Ansprechpartner"
+
+#: filtersets/zone.py:131 filtersets/zone_template.py:88
+msgid "Billing Contact ID"
+msgstr "ID des kaufmännischen Ansprechpartners"
+
+#: filtersets/zone.py:137 filtersets/zone_template.py:94 forms/zone.py:462
+#: forms/zone.py:605 forms/zone.py:786 forms/zone_template.py:138
+#: forms/zone_template.py:199 forms/zone_template.py:261 models/zone.py:227
+#: models/zone_template.py:82 tables/zone.py:64 tables/zone_template.py:41
+#: templates/netbox_dns/zone/registration.html:30
+#: templates/netbox_dns/zonetemplate.html:74
+msgid "Billing Contact"
+msgstr "Kaufmännischer Ansprechpartner"
+
+#: filtersets/zone.py:140
+msgid "Zone is active"
+msgstr "Zone ist aktiv"
+
+#: filtersets/zone_template.py:26
+msgid "Record Template ID"
+msgstr "ID der Datensatzvorlage"
+
+#: filtersets/zone_template.py:32 forms/record_template.py:63
+#: models/record_template.py:93 templates/netbox_dns/recordtemplate.html:12
+#: templates/netbox_dns/zonetemplate.html:85
+msgid "Record Template"
+msgstr "Datensatzvorlage"
+
+#: filtersets/zone_template.py:48
+msgid "Registrar ID"
+msgstr "ID des Registrars"
+
+#: forms/nameserver.py:43 forms/nameserver.py:62 forms/nameserver.py:89
+#: forms/record.py:133 forms/record_template.py:115 forms/registrar.py:71
+#: forms/registration_contact.py:89 forms/registration_contact.py:173
+#: forms/zone.py:132 forms/zone.py:396 models/nameserver.py:33
+#: models/record.py:129 models/record_template.py:32 models/registrar.py:20
+#: models/registration_contact.py:27 models/view.py:31 models/zone.py:92
+#: tables/nameserver.py:15 tables/record.py:40 tables/record_template.py:19
+#: tables/registrar.py:14 tables/view.py:18 tables/zone.py:20
+#: tables/zone_template.py:18 templates/netbox_dns/nameserver.html:11
+#: templates/netbox_dns/record.html:43
+#: templates/netbox_dns/recordtemplate.html:19
+#: templates/netbox_dns/registrar.html:11
+#: templates/netbox_dns/registrationcontact.html:11
+#: templates/netbox_dns/view.html:11 templates/netbox_dns/zone.html:12
+#: templates/netbox_dns/zonetemplate.html:15
+msgid "Name"
+msgstr "Name"
+
+#: forms/nameserver.py:48 forms/nameserver.py:83 forms/record.py:87
+#: forms/record.py:123 forms/record.py:298 forms/record_template.py:65
+#: forms/record_template.py:101 forms/record_template.py:232 forms/view.py:132
+#: forms/view.py:179 forms/view.py:248 forms/zone.py:257 forms/zone.py:381
+#: forms/zone.py:831 forms/zone_template.py:60 forms/zone_template.py:95
+#: forms/zone_template.py:289
+msgid "Tenancy"
+msgstr "Mandantenverhältnis"
+
+#: forms/nameserver.py:49 forms/record.py:88 forms/record_template.py:66
+#: forms/registrar.py:39 forms/zone.py:256 forms/zone_template.py:59
+msgid "Tags"
+msgstr "Tags"
+
+#: forms/nameserver.py:76 forms/nameserver.py:115 forms/record.py:160
+#: forms/record.py:279 forms/record_template.py:132
+#: forms/record_template.py:213 forms/registrar.py:79 forms/registrar.py:129
+#: forms/registration_contact.py:93 forms/registration_contact.py:177
+#: forms/view.py:235 forms/zone.py:157 forms/zone.py:405 forms/zone.py:699
+#: models/nameserver.py:38 models/record.py:184 models/record_template.py:36
+#: models/registrar.py:25 models/registration_contact.py:32 models/view.py:36
+#: models/zone_template.py:22 templates/netbox_dns/nameserver.html:22
+#: templates/netbox_dns/record.html:125
+#: templates/netbox_dns/recordtemplate.html:69
+#: templates/netbox_dns/registrar.html:16
+#: templates/netbox_dns/registrationcontact.html:16
+#: templates/netbox_dns/view.html:20 templates/netbox_dns/zone.html:33
+#: templates/netbox_dns/zone.html:93 templates/netbox_dns/zonetemplate.html:20
+#: templates/netbox_dns/zonetemplate.html:44
+msgid "Description"
+msgstr "Beschreibung"
+
+#: forms/nameserver.py:82 forms/nameserver.py:128 forms/record.py:121
+#: forms/record.py:296 forms/record_template.py:98 forms/record_template.py:230
+#: forms/registrar.py:58 forms/registrar.py:161
+#: forms/registration_contact.py:72 forms/registration_contact.py:225
+#: forms/view.py:177 forms/view.py:246 forms/zone.py:358 forms/zone.py:803
+#: forms/zone_template.py:85 forms/zone_template.py:275
+msgid "Attributes"
+msgstr "Attribute"
+
+#: forms/nameserver.py:95 forms/nameserver.py:120 forms/record.py:217
+#: forms/record.py:284 forms/record_template.py:165
+#: forms/record_template.py:218 forms/view.py:221 forms/view.py:240
+#: forms/zone.py:612 forms/zone.py:791 forms/zone_template.py:205
+#: forms/zone_template.py:266 templates/netbox_dns/nameserver.html:27
+#: templates/netbox_dns/record.html:62
+#: templates/netbox_dns/recordtemplate.html:30
+#: templates/netbox_dns/view.html:25 templates/netbox_dns/zone.html:38
+#: templates/netbox_dns/zonetemplate.html:25
+msgid "Tenant"
+msgstr "Mandant"
+
+#: forms/record.py:62 forms/record.py:156 forms/record.py:187
+#: forms/record.py:251 forms/zone.py:228 models/record.py:133
+#: models/zone.py:275 tables/record.py:28 templates/netbox_dns/record.html:53
+#: templates/netbox_dns/zone.html:9
+msgid "Zone"
+msgstr "Zone"
+
+#: forms/record.py:67 forms/record.py:146 forms/record.py:211
+#: forms/record.py:274 forms/record_template.py:46 forms/record_template.py:128
+#: forms/record_template.py:159 forms/record_template.py:208
+#: models/record.py:179 models/record_template.py:60 tables/record.py:75
+#: tables/record_template.py:41 templates/netbox_dns/record.html:91
+#: templates/netbox_dns/recordtemplate.html:59
+msgid "Disable PTR"
+msgstr "PTR-Erzeugung unterbinden"
+
+#: forms/record.py:71 forms/record.py:207 forms/record.py:269
+#: forms/record_template.py:50 forms/record_template.py:155
+#: forms/record_template.py:204 models/record.py:161
+#: models/record_template.py:55 tables/record.py:57
+#: tables/record_template.py:38 templates/netbox_dns/record.html:86
+#: templates/netbox_dns/recordtemplate.html:54
+#: templates/netbox_dns/zone.html:107
+msgid "TTL"
+msgstr "TTL"
+
+#: forms/record.py:129 forms/record.py:198 forms/record.py:256
+#: forms/record_template.py:107 forms/record_template.py:146
+#: forms/record_template.py:191 models/record.py:145
+#: models/record_template.py:41 tables/record.py:37
+#: tables/record_template.py:26 templates/netbox_dns/record.html:72
+#: templates/netbox_dns/recordtemplate.html:40
+msgid "Type"
+msgstr "Typ"
+
+#: forms/record.py:137 models/record.py:138 tables/record.py:44
+msgid "FQDN"
+msgstr "FQDN"
+
+#: forms/record.py:141 forms/record.py:260 forms/record_template.py:119
+#: forms/record_template.py:195 models/record.py:150
+#: models/record_template.py:45 tables/record.py:48
+#: tables/record_template.py:29 templates/netbox_dns/record.html:76
+#: templates/netbox_dns/recordtemplate.html:44
+msgid "Value"
+msgstr "Wert"
+
+#: forms/record.py:151 forms/record.py:203 forms/record.py:265
+#: forms/record_template.py:124 forms/record_template.py:151
+#: forms/record_template.py:200 forms/zone.py:142 forms/zone.py:392
+#: forms/zone.py:480 forms/zone.py:684 models/record.py:154
+#: models/record_template.py:49 models/zone.py:96 tables/record.py:72
+#: tables/zone.py:32 templates/netbox_dns/recordtemplate.html:64
+#: templates/netbox_dns/zone.html:47
+msgid "Status"
+msgstr "Status"
+
+#: forms/record_template.py:100 forms/record_template.py:137 navigation.py:97
+#: templates/netbox_dns/recordtemplate.html:86
+msgid "Zone Templates"
+msgstr "Zonenvorlagen"
+
+#: forms/record_template.py:111 forms/zone_template.py:100
+#: models/record_template.py:27 models/zone_template.py:17
+#: templates/netbox_dns/recordtemplate.html:15
+msgid "Template Name"
+msgstr "Vorlagenname"
+
+#: forms/registrar.py:65 forms/registration_contact.py:41
+msgid "Contact"
+msgstr "Ansprechpartner"
+
+#: forms/registrar.py:75 forms/registrar.py:133
+#: forms/registration_contact.py:80 forms/registration_contact.py:233
+#: models/registrar.py:45 templates/netbox_dns/registrar.html:30
+msgid "Address"
+msgstr "Adresse"
+
+#: forms/registrar.py:83 forms/registrar.py:125 models/registrar.py:30
+#: templates/netbox_dns/registrar.html:21
+msgid "IANA ID"
+msgstr "IANA-ID"
+
+#: forms/registrar.py:87 forms/registrar.py:137 models/registrar.py:35
+#: templates/netbox_dns/registrar.html:34
+msgid "Referral URL"
+msgstr "Verweis-URL"
+
+#: forms/registrar.py:91 forms/registrar.py:141 models/registrar.py:40
+#: templates/netbox_dns/registrar.html:38
+msgid "WHOIS Server"
+msgstr "WHOIS-Server"
+
+#: forms/registrar.py:95 forms/registrar.py:145 models/registrar.py:50
+#: templates/netbox_dns/registrar.html:42
+msgid "Abuse Email"
+msgstr "Abuse-E-Mail"
+
+#: forms/registrar.py:99 forms/registrar.py:149 models/registrar.py:54
+#: templates/netbox_dns/registrar.html:46
+msgid "Abuse Phone"
+msgstr "Abuse-Telefonnummer"
+
+#: forms/registration_contact.py:83 forms/registration_contact.py:241
+msgid "Communication"
+msgstr "Kommunikation"
+
+#: forms/registration_contact.py:97 models/registration_contact.py:22
+#: tables/registration_contact.py:14
+#: templates/netbox_dns/registrationcontact.html:21
+msgid "Contact ID"
+msgstr "Ansprechpartner-ID"
+
+#: forms/registration_contact.py:101 forms/registration_contact.py:181
+#: models/registration_contact.py:37
+#: templates/netbox_dns/registrationcontact.html:25
+msgid "Organization"
+msgstr "Organisation"
+
+#: forms/registration_contact.py:105 forms/registration_contact.py:185
+#: models/registration_contact.py:42
+#: templates/netbox_dns/registrationcontact.html:29
+msgid "Street"
+msgstr "Straße"
+
+#: forms/registration_contact.py:109 forms/registration_contact.py:189
+#: models/registration_contact.py:47
+#: templates/netbox_dns/registrationcontact.html:33
+msgid "City"
+msgstr "Stadt/Ort"
+
+#: forms/registration_contact.py:113 forms/registration_contact.py:193
+#: models/registration_contact.py:52
+#: templates/netbox_dns/registrationcontact.html:37
+msgid "State/Province"
+msgstr "Bundesland"
+
+#: forms/registration_contact.py:117 forms/registration_contact.py:197
+#: models/registration_contact.py:57
+#: templates/netbox_dns/registrationcontact.html:41
+msgid "Postal Code"
+msgstr "Postleitzahl"
+
+#: forms/registration_contact.py:121 forms/registration_contact.py:201
+#: templates/netbox_dns/registrationcontact.html:45
+msgid "Country"
+msgstr "Land"
+
+#: forms/registration_contact.py:125 forms/registration_contact.py:205
+#: models/registration_contact.py:67
+#: templates/netbox_dns/registrationcontact.html:49
+msgid "Phone"
+msgstr "Telefonnummer"
+
+#: forms/registration_contact.py:129 forms/registration_contact.py:209
+#: models/registration_contact.py:72
+#: templates/netbox_dns/registrationcontact.html:53
+msgid "Phone Extension"
+msgstr "Telefon-Durchwahl"
+
+#: forms/registration_contact.py:133 forms/registration_contact.py:213
+#: models/registration_contact.py:77
+#: templates/netbox_dns/registrationcontact.html:57
+msgid "Fax"
+msgstr "Faxnummer"
+
+#: forms/registration_contact.py:137 forms/registration_contact.py:217
+#: models/registration_contact.py:82
+#: templates/netbox_dns/registrationcontact.html:61
+msgid "Fax Extension"
+msgstr "Fax-Durchwahl"
+
+#: forms/registration_contact.py:141 forms/registration_contact.py:221
+msgid "Email Address"
+msgstr "E-Mail-Adresse"
+
+#: forms/view.py:112
+msgid "You do not have permission to modify assigned prefixes"
+msgstr "Sie haben keine Berechtigung zur Änderung der Zuweisung von Prefixen"
+
+#: forms/view.py:121 models/view.py:45 templates/netbox_dns/view.html:41
+msgid "IPAM Prefixes"
+msgstr "IPAM-Prefixe"
+
+#: forms/view.py:125
+msgid "Specify criteria for address record creation in JSON form"
+msgstr ""
+"Geben Sie Kriterien für die Erzeugung von Adress-Datensatz in JSON-Format an"
+
+#: forms/view.py:126 models/view.py:51
+msgid "IP Address Filter"
+msgstr "IP-Adressfilter"
+
+#: forms/view.py:161
+#, python-brace-format
+msgid "Invalid filter for IPAddress: {error}"
+msgstr "Ungültiger IP-Adressfilter: {error}"
+
+#: forms/view.py:214
+msgid "Prefix IDs assigned to the view"
+msgstr "Prefix-ID, die der Ansicht zugeordnet ist"
+
+#: forms/view.py:215
+#, fuzzy
+#| msgid "Prefix"
+msgid "Prefixes"
+msgstr "Prefix"
+
+#: forms/view.py:259
+msgid ""
+"Explicitly assigning DNS views overrides all inherited views for this prefix"
+msgstr ""
+"Explizite Zuweisung einer DNS-Ansicht übersteuert alle ererbten Ansichten "
+"für dieses Prefix"
+
+#: forms/view.py:261 templates/netbox_dns/view/related.html:12
+msgid "Assigned DNS Views"
+msgstr "Zugordnete DNS-Ansichten"
+
+#: forms/view.py:280
+msgid "You do not have permission to modify assigned views"
+msgstr "Sie haben keine Berechtigung zur Änderung der Zuweisung von Ansichten"
+
+#: forms/zone.py:137 forms/zone.py:618
+msgid "Template"
+msgstr "Vorlage"
+
+#: forms/zone.py:151
+msgid "Default TTL for new records in this zone"
+msgstr "Standard-TTL für neue Datensätze in dieser Zone"
+
+#: forms/zone.py:153 forms/zone.py:490 forms/zone.py:694 models/zone.py:109
+#: templates/netbox_dns/zone.html:89
+msgid "Default TTL"
+msgstr "Standard-TTL"
+
+#: forms/zone.py:161 forms/zone.py:494
+msgid "TTL for the SOA record of the zone"
+msgstr "TTL des SOA-Datensatzes der Zone"
+
+#: forms/zone.py:163 forms/zone.py:495 forms/zone.py:704 models/zone.py:114
+msgid "SOA TTL"
+msgstr "SOA-TTL"
+
+#: forms/zone.py:167 forms/zone.py:509
+msgid "Mailbox of the zone's administrator"
+msgstr "Postfach des Zonenadministrators"
+
+#: forms/zone.py:168 forms/zone.py:510 forms/zone.py:713 models/zone.py:128
+msgid "SOA RName"
+msgstr "SOA-RName"
+
+#: forms/zone.py:172 forms/zone.py:522
+msgid "Refresh interval for secondary nameservers"
+msgstr "Auffrischungsintervall für sekundäre Nameserver"
+
+#: forms/zone.py:174 forms/zone.py:523 forms/zone.py:728 models/zone.py:140
+msgid "SOA Refresh"
+msgstr "SOA-Auffrischungsintervall"
+
+#: forms/zone.py:178 forms/zone.py:527
+msgid "Retry interval for secondary nameservers"
+msgstr "Wiederholungsintervall für sekundäre Nameserver"
+
+#: forms/zone.py:180 forms/zone.py:528 forms/zone.py:733 models/zone.py:146
+msgid "SOA Retry"
+msgstr "SOA-Wiederholungsintervall"
+
+#: forms/zone.py:185 forms/zone.py:532
+msgid "Expire time after which the zone is considered unavailable"
+msgstr "Zeit, nach der der primäre Nameserver als ausgefallen angesehen wird"
+
+#: forms/zone.py:186 forms/zone.py:533 forms/zone.py:738 models/zone.py:152
+msgid "SOA Expire"
+msgstr "SOA-Ablaufzeit"
+
+#: forms/zone.py:190
+msgid "Minimum TTL for negative results, e.g. NXRRSET"
+msgstr "Minimale TTL für negative Resultate wie NXRRSET"
+
+#: forms/zone.py:192 forms/zone.py:538 forms/zone.py:743 models/zone.py:158
+msgid "SOA Minimum TTL"
+msgstr "SOA-Minimal-TTL"
+
+#: forms/zone.py:196 models/zone.py:165
+#, fuzzy
+msgid "Automatically generate the SOA serial number"
+msgstr "Die SOA-Seriennummer automatisch erzeugen"
+
+#: forms/zone.py:197 forms/zone.py:419 forms/zone.py:514 forms/zone.py:718
+#: models/zone.py:164
+msgid "Generate SOA Serial"
+msgstr "SOA-Seriennummer erzeugen"
+
+#: forms/zone.py:202 forms/zone.py:518 forms/zone.py:723 models/zone.py:134
+msgid "SOA Serial"
+msgstr "SOA-Seriennummer"
+
+#: forms/zone.py:208 forms/zone.py:542 forms/zone.py:748 models/zone.py:237
+msgid "RFC2317 IPv4 prefix with a length of at least 25 bits"
+msgstr "RFC2317-IPv4-Prefix mit einer Länge von mindestens 25 Bit"
+
+#: forms/zone.py:214 forms/zone.py:548 forms/zone.py:755
+msgid ""
+"IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in "
+"NetBox DNS"
+msgstr ""
+"Die IPv4-Reverse-Lookup-Zone für die Delegation der RFC2317-PTR-Datensatzes "
+"wird in NetBox DNS verwaltet"
+
+#: forms/zone.py:216 forms/zone.py:550 forms/zone.py:757 models/zone.py:242
+msgid "RFC2317 Parent Managed"
+msgstr "Übergeordnete RFC2317-Zone ist verwaltet"
+
+#: forms/zone.py:240 forms/zone.py:364 forms/zone.py:815
+msgid "SOA"
+msgstr "SOA"
+
+#: forms/zone.py:245 forms/zone.py:370 forms/zone.py:820
+#: templates/netbox_dns/zone.html:149
+msgid "RFC2317"
+msgstr "RFC2317"
+
+#: forms/zone.py:254 forms/zone.py:829 forms/zone_template.py:57
+#: forms/zone_template.py:287 navigation.py:198
+#: templates/netbox_dns/zone/registration.html:7
+#: templates/netbox_dns/zonetemplate.html:55
+msgid "Domain Registration"
+msgstr "Domänenregistrierung"
+
+#: forms/zone.py:379 forms/zone_template.py:93
+msgid "Registration"
+msgstr "Registrierung"
+
+#: forms/zone.py:410 templates/netbox_dns/zone.html:111
+msgid "MName"
+msgstr "MName"
+
+#: forms/zone.py:414 templates/netbox_dns/zone.html:115
+msgid "RName"
+msgstr "RName"
+
+#: forms/zone.py:428 templates/netbox_dns/zone.html:156
+msgid "Parent Managed"
+msgstr "Übergeordnete Zone ist verwaltet"
+
+#: forms/zone.py:442 forms/zone.py:565 forms/zone.py:766 models/zone.py:194
+#: templates/netbox_dns/zone/registration.html:14
+msgid "Registry Domain ID"
+msgstr "Domänen-ID beim Registrar"
+
+#: forms/zone.py:473
+msgid "View not found."
+msgstr "Ansicht nicht gefunden."
+
+#: forms/zone.py:475
+#, fuzzy
+#| msgctxt "DNS"
+#| msgid "View"
+msgid "View"
+msgstr "Ansicht"
+
+#: forms/zone.py:502
+msgid "Nameserver not found."
+msgstr "Nameserver nicht gefunden."
+
+#: forms/zone.py:537
+#, fuzzy
+#| msgid "Minimum TTL for negative results, e.g. NXRRSET"
+msgid "Minimum TTL for negative results, e.g. NXRRSET, NXDOMAIN"
+msgstr "Minimale TTL für negative Resultate wie NXRRSET"
+
+#: forms/zone.py:557 forms/zone_template.py:161
+msgid "Registrar not found."
+msgstr "Registrar nicht gefunden."
+
+#: forms/zone.py:564
+msgid "Domain ID assigned by the registry"
+msgstr "Domänen-ID, die vom Registrar zugewiesen wurde"
+
+#: forms/zone.py:572 forms/zone_template.py:170
+msgid "Registrant contact ID not found"
+msgstr "Ansprechpartner-ID des Domäneninhabers nicht gefunden"
+
+#: forms/zone.py:574
+msgid "Owner of the domain"
+msgstr "Inhaber der Domäne"
+
+#: forms/zone.py:583 forms/zone_template.py:179
+msgid "Administrative contact ID not found"
+msgstr "Ansprechpartner-ID des administrativen Ansprechpartners nicht gefunden"
+
+#: forms/zone.py:593 forms/zone_template.py:188
+msgid "Technical contact ID not found"
+msgstr "Ansprechpartner-ID des technischen Ansprechpartners nicht gefunden"
+
+#: forms/zone.py:603 forms/zone_template.py:197
+msgid "Billing contact ID not found"
+msgstr "Ansprechpartner-ID des kaufmännischen Ansprechpartners nicht gefunden"
+
+#: forms/zone.py:611
+msgid "Assigned tenant"
+msgstr "Zugeordneter Mandant"
+
+#: forms/zone_template.py:50 forms/zone_template.py:86
+#: forms/zone_template.py:110 forms/zone_template.py:235
+#: forms/zone_template.py:279 models/record_template.py:94
+#: models/zone_template.py:33 navigation.py:117
+#: templates/netbox_dns/zonetemplate.html:87
+msgid "Record Templates"
+msgstr "Datensatzvorlagen"
+
+#: forms/zone_template.py:154
+#, fuzzy
+#| msgid "Record Templates"
+msgid "Record Remplates"
+msgstr "Datensatzvorlagen"
+
+#: models/record.py:166
+msgid "Managed"
+msgstr "Verwaltet"
+
+#: models/record.py:180 models/record_template.py:61
+msgid "Disable PTR record creation"
+msgstr "Erzeugung eines PTR-Datensatzes unterbinden"
+
+#: models/record.py:196 tables/record.py:112
+msgid "Related IP Address"
+msgstr "Zugeordnete IP-Adresse"
+
+#: models/record.py:197
+msgid "IP address related to an address (A/AAAA) or PTR record"
+msgstr ""
+"IP-Adresse, die einem Adress- (A/AAAA) oder Zeiger-Datensatz (PTR) "
+"zugeordnet ist"
+
+#: models/record.py:210
+msgid "RFC2317 CNAME Record"
+msgstr "RCF2317-CNNAME-Datensatz"
+
+#: models/record.py:233 templates/netbox_dns/record.html:40
+msgid "Record"
+msgstr "Datensatz"
+
+#: models/record.py:234 navigation.py:71 views/zone.py:132
+msgid "Records"
+msgstr "Datensätze"
+
+#: models/record.py:549
+#, python-brace-format
+msgid "{name} is not a name in {zone}"
+msgstr "{name} liegt nicht in Zone {zone}"
+
+#: models/record.py:636
+#, python-brace-format
+msgid ""
+"There is already an active {type} record for name {name} in zone {zone} with "
+"value {value}."
+msgstr ""
+"Es gibt bereits einen aktiven {type}-Datensatz mit dem Namen {name} in Zone "
+"{zone} mit dem Wert {value}."
+
+#: models/record.py:699
+#, python-brace-format
+msgid ""
+"There is at least one active {type} record for name {name} in zone {zone} "
+"and TTL is different ({ttls})."
+msgstr ""
+"Es gibt bereits mindestens einen aktiven {type}-Datensatz mit dem Namen "
+"{name} in Zone {zone} mit abweichender TTL ({ttls}) "
+
+#: models/record.py:786
+#, python-brace-format
+msgid ""
+"There is already an active record for name {name} in zone {zone}, RFC2317 "
+"CNAME is not allowed."
+msgstr ""
+"Es gibt bereits einen aktiven Datensatz mit dem Namen {name} in Zone {zone}. "
+"Der RFC2317-CNAME kann nicht angelegt werden."
+
+#: models/record.py:795
+msgid ""
+"SOA records are only allowed with name @ and are created automatically by "
+"NetBox DNS"
+msgstr ""
+"SOA-Datensätze sind ausschließlich mit dem Namen @ erlaubt und werden "
+"automatisch von NetBox DNS erzeugt"
+
+#: models/record.py:805
+#, python-brace-format
+msgid ""
+"There is already an active record for name {name} in zone {zone}, CNAME is "
+"not allowed."
+msgstr ""
+"Es gibt bereits einen aktiven Datensatz mit dem Namen {name} in Zone {zone}. "
+"Der CNAME kann nicht angelegt werden."
+
+#: models/record.py:817
+#, python-brace-format
+msgid ""
+"There is already an active CNAME record for name {name} in zone {zone}, no "
+"other record allowed."
+msgstr ""
+"Es gibt bereits einen aktiven CNAME-Datensatz mit dem Namen {name} in Zone "
+"{zone}. Ein anderer Datensatz mit dem gleichen Namen kann nicht angelegt "
+"werden."
+
+#: models/record.py:827
+#, python-brace-format
+msgid ""
+"There is already an active {type} record for name {name} in zone {zone}, "
+"more than one are not allowed."
+msgstr ""
+"Es gibt bereits einen aktiven {type}-Datensatz mit dem Namen {name} in Zone "
+"{zone}. Mehr als ein Datensatz dieses Typs kann nicht angelegt werden."
+
+#: models/record_template.py:163
+#, python-brace-format
+msgid "Error while processing record template {template}: {error}"
+msgstr "Fehler bei der Verarbeitung der Datensatzvorlage {template}: {error}"
+
+#: models/registrar.py:67 navigation.py:137
+msgid "Registrars"
+msgstr "Registrare"
+
+#: models/registration_contact.py:62
+msgid "Country (ISO 3166)"
+msgstr "Ländercode (ISO 3166)"
+
+#: models/registration_contact.py:87
+#: templates/netbox_dns/registrationcontact.html:65
+msgid "Email"
+msgstr "E-Mail"
+
+#: models/registration_contact.py:123
+#: templates/netbox_dns/registrationcontact.html:8
+msgid "Registration Contact"
+msgstr "Ansprechpartner"
+
+#: models/registration_contact.py:124 navigation.py:157
+msgid "Registration Contacts"
+msgstr "Ansprechpartner"
+
+#: models/view.py:41 tables/view.py:22 templates/netbox_dns/view.html:15
+msgid "Default View"
+msgstr "Standardansicht"
+
+#: models/view.py:87 models/view.py:89
+msgid "The default view cannot be deleted"
+msgstr "Die Standardansicht kann nicht gelöscht werden"
+
+#: models/view.py:105
+msgid "Please select a different view as default view to change this setting!"
+msgstr ""
+"Bitte wählen Sie eine andere Ansicht als Standardansicht aus, um diese "
+"Einstellung zu ändern!"
+
+#: models/zone.py:174
+msgid "Network related to a reverse lookup zone (.arpa)"
+msgstr "Zugrundeliegendes Netz einer Revese-Lookup-Zone (.arpa)"
+
+#: models/zone.py:195
+#, fuzzy
+msgid "ID of the domain assigned by the registry"
+msgstr "ID einer Domäne, die von der Registry zugewiesen wurde"
+
+#: models/zone.py:243
+msgid "The parent zone for the RFC2317 zone is managed by NetBox DNS"
+msgstr "Die übergeordnete Zone einer RFC2317-Zone wird in NetBox DNS verwaltet"
+
+#: models/zone.py:251
+msgid "Parent zone for RFC2317 reverse zones"
+msgstr "Übergeordnete Zone von RFC2317-Reverse-Lookup-Zonen"
+
+#: models/zone.py:463
+#, python-brace-format
+msgid "No nameservers are configured for zone {zone}"
+msgstr "Für Zone {zone} wurden keine Nameserver konfiguriert"
+
+#: models/zone.py:489
+#, python-brace-format
+msgid ""
+"Nameserver {nameserver} does not have an active address record in zone {zone}"
+msgstr ""
+"Nameserver {nameserver} hat keinen aktiven Adressdatensatz in Zone {zone}"
+
+#: models/zone.py:506
+#, python-brace-format
+msgid "soa_serial must not decrease for zone {zone}."
+msgstr "soa_serial für Zone {zone} darf nicht verringert werden"
+
+#: models/zone.py:619
+#, python-brace-format
+msgid "Default soa_mname instance {nameserver} does not exist"
+msgstr "Standardnameserver für soa_mname {nameserver} existiert nicht"
+
+#: models/zone.py:649
+msgid "soa_rname not set and no default value defined"
+msgstr ""
+"soa_rname wurde nicht angegeben und es ist kein Standardwert konfiguriert"
+
+#: models/zone.py:665
+#, python-brace-format
+msgid ""
+"soa_serial is not defined and soa_serial_auto is disabled for zone {zone}."
+msgstr ""
+"soa_serial wurde nicht angegeben und soa_serial_auto ist für Zone {zone} "
+"nicht eingeschaltet."
+
+#: models/zone.py:685
+#, python-brace-format
+msgid "Enabling soa_serial_auto would decrease soa_serial for zone {zone}."
+msgstr ""
+"Das Einschalten von soa_serial_auto würde die SOA-Seriennummer für Zone "
+"{zone} verringern."
+
+#: models/zone.py:721
+msgid "A regular reverse zone can not be used as an RFC2317 zone."
+msgstr ""
+"Eine normale Reverse-Lookup-Zone kann nicht als RFC2317-Zone verwendet "
+"werden."
+
+#: models/zone.py:733
+#, python-brace-format
+msgid "Parent zone not found in view {view}."
+msgstr "Die übergeordnete Zone wurde nicht in Ansicht {view} gefunden."
+
+#: models/zone.py:752
+#, python-brace-format
+msgid "RFC2317 prefix overlaps with zone {zone}."
+msgstr "Das RFC2317-Prefix überlappt mit dem von Zone {zone}."
+
+#: models/zone_template.py:59
+#, fuzzy
+msgid "Registrar of the domain"
+msgstr "Inhaber der Domäne"
+
+#: navigation.py:11
+msgid "Views"
+msgstr "Ansichten"
+
+#: navigation.py:16 navigation.py:36 navigation.py:56 navigation.py:76
+#: navigation.py:102 navigation.py:122 navigation.py:142 navigation.py:162
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: navigation.py:22 navigation.py:42 navigation.py:62 navigation.py:82
+#: navigation.py:108 navigation.py:128 navigation.py:148 navigation.py:168
+msgid "Import"
+msgstr "Importieren"
+
+#: navigation.py:91 templates/netbox_dns/record.html:18
+#: templates/netbox_dns/record/managed.html:4 views/zone.py:154
+msgid "Managed Records"
+msgstr "Verwaltete Datensätze"
+
+#: navigation.py:181
+msgid "DNS Configuration"
+msgstr "DNS-Konfiguration"
+
+#: navigation.py:191
+msgid "Templates"
+msgstr "Vorlagen"
+
+#: signals/ipam_dnssync.py:65
+#, python-brace-format
+msgid ""
+"Unique DNS records are enforced and there is already an active IP address "
+"{address} with DNS name {name}. Plesase choose a different name or disable "
+"record creation for this IP address."
+msgstr ""
+"Eindeutige DNS-Datensätze werden erzwungen und es gibt bereits eine aktive "
+"IP-Adresse {address} mit dem DNS-Namen {name}, Bitte wählen Sie einen "
+"anderen Namen oder unterbinden Sie die Erzeugung von Adress-Datensätzen für "
+"diese IP-Adresse."
+
+#: signals/ipam_dnssync.py:100
+msgid "You do not have permission to alter DNSsync custom fields"
+msgstr "Sie haben keine Berechtigung zur Änderung von DNSsync-Sonderfeldern"
+
+#: signals/ipam_dnssync.py:144
+#, fuzzy, python-brace-format
+msgid ""
+"This prefix is currently assigned to the following DNS views: {views}. "
+"Please deassign it from these views before making changes to the prefix or "
+"VRF."
+msgstr ""
+"Dieses Prefix ist derzeit den folgenden DNS-Ansichten zugeordnet: {views}. "
+"Bitte entfernen Sie diese Zuweisung, bevor Sie Änderungen am Prefix oder VRF "
+"vornehmen."
+
+#: signals/ipam_dnssync.py:152
+#, python-brace-format
+msgid ""
+"Prefix is assigned to DNS views {views}. Prefix and VRF must not be changed"
+msgstr ""
+"Das Prefix ist den folgenden DNS-Ansichten zugeordnet: {views}. Prefix und "
+"VRF können nicht geändert werden"
+
+#: signals/ipam_dnssync.py:175
+#, python-brace-format
+msgid ""
+"Prefix deletion would cause DNS errors: {errors}. Please review DNS View "
+"assignments for this and the parent prefix"
+msgstr ""
+"Die Löschung dieses Prefixes würde DNS-Fehler veursachen: {errors}. Bitte "
+"prüfen Sie die Zuweisungen von DNS-Ansichten für dieses und das "
+"übergeordnete Prefix"
+
+#: tables/ipam_dnssync.py:8 templates/netbox_dns/view/button.html:7
+msgid "DNS Views"
+msgstr "DNS-Ansichten"
+
+#: tables/record.py:52 tables/record_template.py:33
+#: templates/netbox_dns/record.html:81
+#: templates/netbox_dns/recordtemplate.html:49
+msgid "Unicode Value"
+msgstr "Unicode-Wert"
+
+#: tables/record.py:81 templates/netbox_dns/record.html:97
+msgid "PTR Record"
+msgstr "PTR-Datensatz"
+
+#: tables/record_template.py:23
+msgid "Record Name"
+msgstr "Datensatzname"
+
+#: templates/netbox_dns/nameserver.html:16 templates/netbox_dns/record.html:48
+#: templates/netbox_dns/recordtemplate.html:24
+#: templates/netbox_dns/zone.html:17
+msgid "IDN"
+msgstr "IDN"
+
+#: templates/netbox_dns/record.html:134
+msgid "CNAME Target"
+msgstr "CNAME-Zieldatensatz"
+
+#: templates/netbox_dns/record.html:136
+msgid "CNAME Targets"
+msgstr "CNAME-Zieldatensätze"
+
+#: templates/netbox_dns/record.html:145
+msgid "CNAME"
+msgstr "CNAME"
+
+#: templates/netbox_dns/record.html:147
+msgid "CNAMEs"
+msgstr "CNAMEs"
+
+#: templates/netbox_dns/record/related.html:9
+msgid "Related DNS Address Record"
+msgstr "Zugehöriger DNS-Adress-Datensatz"
+
+#: templates/netbox_dns/record/related.html:11
+msgid "Related DNS Address Records"
+msgstr "Zugehörige DNS-Adress-Datensätze"
+
+#: templates/netbox_dns/record/related.html:21
+msgid "Related DNS Pointer Record"
+msgstr "Zugehöriger DNS-Zeiger-Datensatz"
+
+#: templates/netbox_dns/record/related.html:23
+msgid "Related DNS Pointer Records"
+msgstr "Zugehörige DNS-Zeiger-Datensätze"
+
+#: templates/netbox_dns/registrar.html:27
+msgid "Contact Details"
+msgstr "Ansprechpartner-Details"
+
+#: templates/netbox_dns/view.html:8 templates/netbox_dns/zone.html:28
+msgctxt "DNS"
+msgid "View"
+msgstr "Ansicht"
+
+#: templates/netbox_dns/view.html:55
+msgid "Global"
+msgstr "Global"
+
+#: templates/netbox_dns/view.html:60
+msgid "No prefixes assigned"
+msgstr "Keine Prefixe zugeordnet"
+
+#: templates/netbox_dns/view.html:66
+msgid "IP Address Filters"
+msgstr "IP-Adress-Filter"
+
+#: templates/netbox_dns/view.html:71
+msgid "No filters defined"
+msgstr "Keine Filter definiert"
+
+#: templates/netbox_dns/view/prefix.html:5
+#, python-format
+msgid "Configure DNS views for %(type)s %(name)s %(vrf)s"
+msgstr "DNS-Ansichten für %(type)s %(name)s %(vrf)s konfigurieren"
+
+#: templates/netbox_dns/view/prefix.html:20
+msgid "Views inherited from prefix"
+msgstr "Ansichten ererbt von Prefix"
+
+#: templates/netbox_dns/view/prefix.html:34
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: templates/netbox_dns/view/prefix.html:35
+msgid "Save"
+msgstr "Speichern"
+
+#: templates/netbox_dns/view/related.html:10
+msgid "Assigned DNS View"
+msgstr "Zugeordnete DNS-Ansichten"
+
+#: templates/netbox_dns/view/related.html:23
+msgid "Inherited DNS View"
+msgstr "Ererbte DNS-Ansicht"
+
+#: templates/netbox_dns/view/related.html:25
+msgid "Inherited DNS Views"
+msgstr "Ererbte DNS-Ansichten"
+
+#: templates/netbox_dns/zone.html:61
+msgid "Warnings"
+msgstr "Warnungen"
+
+#: templates/netbox_dns/zone.html:75
+msgid "Errors"
+msgstr "Fehlermeldungen"
+
+#: templates/netbox_dns/zone.html:104
+msgid "Zone SOA"
+msgstr "Zonen-SOA"
+
+#: templates/netbox_dns/zone.html:120
+msgid "Serial (auto-generated)"
+msgstr "Seriennummer (automatisch erzeugt)"
+
+#: templates/netbox_dns/zone.html:125
+msgctxt "SOA"
+msgid "Serial"
+msgstr "Seriennummer"
+
+#: templates/netbox_dns/zone.html:130
+msgid "Refresh"
+msgstr "Auffrischungs-Intervall"
+
+#: templates/netbox_dns/zone.html:134
+msgid "Retry"
+msgstr "Wiederholungs-Intervall"
+
+#: templates/netbox_dns/zone.html:138
+msgid "Expire"
+msgstr "Ablaufzeit"
+
+#: templates/netbox_dns/zone.html:142
+msgid "Minimum TTL"
+msgstr "Minimale TTL"
+
+#: templates/netbox_dns/zone/base.html:12
+msgid "Add Record"
+msgstr "Datensatz hinzufügen"
+
+#: templates/netbox_dns/zone/child.html:27
+#: templates/netbox_dns/zone/record.html:27
+msgid "Edit Selected"
+msgstr "Ausgewählte bearbeiten"
+
+#: templates/netbox_dns/zone/child.html:32
+#: templates/netbox_dns/zone/record.html:32
+msgid "Delete Selected"
+msgstr "Ausgewählte löschen"
+
+#: validators/dns_name.py:60
+#, python-brace-format
+msgid "{name} is not a valid fully qualified DNS host name"
+msgstr "{name} ist kein gültiger vollständiger DNS-Hostname"
+
+#: validators/dns_name.py:69
+#, python-brace-format
+msgid "{name} is not a valid RName"
+msgstr "{name} ist kein gültiger RName"
+
+#: validators/dns_name.py:83
+#, python-brace-format
+msgid "{name} is not a valid DNS host name"
+msgstr "{name} ist kein gültiger DNS-Hostname"
+
+#: validators/dns_name.py:106
+#, python-brace-format
+msgid "{name} is not a valid DNS domain name"
+msgstr "{name} ist kein gültiger DNS-Domänenname"
+
+#: validators/dns_value.py:34
+#, python-brace-format
+msgid "Record value {value} is not a valid value for a {type} record: {error}."
+msgstr ""
+"Der Wert {value} des Datensatzes ist kein gültiger Wert für {type}-"
+"Datensätze: {error}."
+
+#: validators/rfc2317.py:15
+#, python-brace-format
+msgid "{prefix} is not a valid prefix. Did you mean {cidr}?"
+msgstr "{prefix} ist kein gültiges Prefix. Meinen Sie {cidr}?"
+
+#: validators/rfc2317.py:23
+msgid "RFC2317 requires an IPv4 prefix."
+msgstr "RFC2317 erfordert ein IPv4-Prefix"
+
+#: validators/rfc2317.py:28
+msgid "RFC2317 requires at least 25 bit prefix length."
+msgstr "RFC2317 erfordert ein Prefix von mindestens 25 Bit Länge."
+
+#: views/zone.py:175
+msgid "RFC2317 Child Zones"
+msgstr "Untergeordnete RFC2317-Zonen"
+
+#: views/zone.py:194
+msgid "Child Zones"
+msgstr "Untergeordnete Zonen"

--- a/netbox_dns/locale/en/LC_MESSAGES/django.po
+++ b/netbox_dns/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,1292 @@
+# English translations for the NetBox DNS plugin
+# Copyright (C) 2024
+# This file is distributed under the same license as the NetBox DNS plugin.
+# Peter Eckel <pete@netbox-dns.org>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.1.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-30 15:06+0000\n"
+"PO-Revision-Date: 2024-09-29 12:06+0000\n"
+"Last-Translator: Peter Eckel <pete@netbox-dns.org>\n"
+"Language-Team: LANGUAGE  <language@netbox-dns.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: __init__.py:14
+msgid "NetBox DNS"
+msgstr ""
+
+#: __init__.py:15
+msgid "NetBox plugin for DNS data"
+msgstr ""
+
+#: api/nested_serializers.py:41 api/serializers_/zone.py:31 forms/zone.py:343
+msgid "View the zone belongs to"
+msgstr ""
+
+#: api/nested_serializers.py:86 api/serializers_/record.py:37
+msgid "Zone the record belongs to"
+msgstr ""
+
+#: api/serializers_/nameserver.py:24
+msgid "Zones served by the authoritative nameserver"
+msgstr ""
+
+#: api/serializers_/record.py:25
+msgid "PTR record generated from an address"
+msgstr ""
+
+#: api/serializers_/record.py:32
+msgid "Address record defining the PTR"
+msgstr ""
+
+#: api/serializers_/record.py:49
+msgid "IPAddress linked to the record"
+msgstr ""
+
+#: api/serializers_/record_template.py:24
+msgid "Zone templates using the record template"
+msgstr ""
+
+#: api/serializers_/view.py:26
+msgid "IPAM Prefixes assigned to the View"
+msgstr ""
+
+#: api/serializers_/zone.py:38 api/serializers_/zone_template.py:27
+msgid "Nameservers for the zone"
+msgstr ""
+
+#: api/serializers_/zone.py:45 forms/zone.py:344 forms/zone.py:504
+msgid "Primary nameserver for the zone"
+msgstr ""
+
+#: api/serializers_/zone.py:51
+msgid "RFC2317 parent zone of the zone"
+msgstr ""
+
+#: api/serializers_/zone.py:57
+msgid "RFC2317 child zones of the zone"
+msgstr ""
+
+#: api/serializers_/zone.py:64 api/serializers_/zone_template.py:40
+#: forms/zone.py:559 models/zone.py:189 models/zone_template.py:50
+msgid "Registrar the domain is registered with"
+msgstr ""
+
+#: api/serializers_/zone.py:71 api/serializers_/zone_template.py:47
+#: models/zone.py:204
+msgid "Registrant of the domain"
+msgstr ""
+
+#: api/serializers_/zone.py:78 api/serializers_/zone_template.py:54
+#: forms/zone.py:581 models/zone.py:213 models/zone_template.py:68
+msgid "Administrative contact for the domain"
+msgstr ""
+
+#: api/serializers_/zone.py:85 api/serializers_/zone_template.py:61
+#: forms/zone.py:591 models/zone.py:222 models/zone_template.py:77
+msgid "Technical contact for the domain"
+msgstr ""
+
+#: api/serializers_/zone.py:92 api/serializers_/zone_template.py:68
+#: forms/zone.py:601 models/zone.py:231 models/zone_template.py:86
+msgid "Billing contact for the domain"
+msgstr ""
+
+#: api/serializers_/zone.py:99
+msgid "Template to apply to the zone"
+msgstr ""
+
+#: api/serializers_/zone_template.py:33
+msgid "Record templates assigned to the zone template"
+msgstr ""
+
+#: api/views.py:84
+msgid "'managed' is True, refusing create"
+msgstr ""
+
+#: api/views.py:92
+#, python-brace-format
+msgid "{object} is managed, refusing deletion"
+msgstr ""
+
+#: api/views.py:101
+#, python-brace-format
+msgid "{object} is managed, refusing update"
+msgstr ""
+
+#: api/views.py:106
+#, python-brace-format
+msgid "{object} is unmanaged, refusing update to managed"
+msgstr ""
+
+#: choices/record.py:49 choices/zone.py:18 tables/record.py:60
+msgid "Active"
+msgstr ""
+
+#: choices/record.py:50
+msgid "Inactive"
+msgstr ""
+
+#: choices/zone.py:19
+msgid "Reserved"
+msgstr ""
+
+#: choices/zone.py:20
+msgid "Deprecated"
+msgstr ""
+
+#: choices/zone.py:21
+msgid "Parked"
+msgstr ""
+
+#: fields/address.py:32
+msgid "IPv4/v6 address"
+msgstr ""
+
+#: fields/network.py:80
+msgid "IPv4/v6 network associated with a reverse lookup zone"
+msgstr ""
+
+#: fields/rfc2317.py:12
+msgid "RFC2317 requires an IPv4 prefix with a length of at least 25 bits."
+msgstr ""
+
+#: fields/rfc2317.py:34
+msgid "Please specify the prefix length"
+msgstr ""
+
+#: fields/rfc2317.py:48
+msgid "PostgreSQL CIDR field for an RFC2317 prefix"
+msgstr ""
+
+#: filtersets/nameserver.py:19 forms/nameserver.py:67 models/zone.py:276
+#: navigation.py:31 views/nameserver.py:96 views/registrar.py:80
+#: views/registration_contact.py:83 views/view.py:100
+msgid "Zones"
+msgstr ""
+
+#: filtersets/nameserver.py:24 forms/nameserver.py:72 views/nameserver.py:116
+msgid "SOA Zones"
+msgstr ""
+
+#: filtersets/record.py:32
+msgid "Parent Zone ID"
+msgstr ""
+
+#: filtersets/record.py:38 forms/zone.py:433 templates/netbox_dns/zone.html:23
+#: templates/netbox_dns/zone.html:161
+msgid "Parent Zone"
+msgstr ""
+
+#: filtersets/record.py:43
+msgid "ID of the View the Parent Zone belongs to"
+msgstr ""
+
+#: filtersets/record.py:49
+msgid "View the Parent Zone belongs to"
+msgstr ""
+
+#: filtersets/record.py:55 tables/record.py:104
+#: templates/netbox_dns/record.html:103
+msgid "Address Record"
+msgstr ""
+
+#: filtersets/record.py:61 filtersets/record.py:67
+msgid "Pointer Record"
+msgstr ""
+
+#: filtersets/record.py:73 models/record.py:202 tables/record.py:108
+#: templates/netbox_dns/record.html:108 templates/netbox_dns/record.html:115
+msgid "IPAM IP Address"
+msgstr ""
+
+#: filtersets/record.py:77
+msgid "IP Address"
+msgstr ""
+
+#: filtersets/record_template.py:26 forms/zone_template.py:49
+#: models/zone_template.py:113 templates/netbox_dns/recordtemplate.html:84
+#: templates/netbox_dns/zonetemplate.html:12
+msgid "Zone Template"
+msgstr ""
+
+#: filtersets/record_template.py:32
+msgid "Zone Template ID"
+msgstr ""
+
+#: filtersets/view.py:21
+msgid "Prefix ID"
+msgstr ""
+
+#: filtersets/view.py:27 forms/view.py:198 forms/zone.py:423
+#: templates/netbox_dns/zone.html:152
+msgid "Prefix"
+msgstr ""
+
+#: filtersets/zone.py:25
+msgid "View ID"
+msgstr ""
+
+#: filtersets/zone.py:38
+msgid "Nameserver IDs"
+msgstr ""
+
+#: filtersets/zone.py:45 forms/zone.py:147 forms/zone.py:401 forms/zone.py:486
+#: forms/zone.py:689 forms/zone_template.py:105 forms/zone_template.py:148
+#: forms/zone_template.py:230 models/nameserver.py:57
+#: models/zone_template.py:27 navigation.py:51
+#: templates/netbox_dns/zone.html:51 templates/netbox_dns/zonetemplate.html:34
+msgid "Nameservers"
+msgstr ""
+
+#: filtersets/zone.py:51 filtersets/zone_template.py:38
+msgid "Nameservers ID"
+msgstr ""
+
+#: filtersets/zone.py:57 filtersets/zone_template.py:44 forms/nameserver.py:47
+#: models/nameserver.py:56 models/zone.py:103
+#: templates/netbox_dns/nameserver.html:8
+msgid "Nameserver"
+msgstr ""
+
+#: filtersets/zone.py:61
+msgid "SOA MName ID"
+msgstr ""
+
+#: filtersets/zone.py:67 forms/zone.py:505 forms/zone.py:709 models/zone.py:120
+#: tables/zone.py:28
+msgid "SOA MName"
+msgstr ""
+
+#: filtersets/zone.py:71 models/zone.py:173
+msgid "ARPA Network"
+msgstr ""
+
+#: filtersets/zone.py:75 forms/zone.py:209 forms/zone.py:543 forms/zone.py:749
+#: models/zone.py:236 tables/zone.py:41
+msgid "RFC2317 Prefix"
+msgstr ""
+
+#: filtersets/zone.py:81 filtersets/zone.py:87 models/zone.py:247
+#: tables/zone.py:44
+msgid "RFC2317 Parent Zone"
+msgstr ""
+
+#: filtersets/zone.py:97 filtersets/zone_template.py:54 forms/registrar.py:37
+#: forms/zone.py:438 forms/zone.py:560 forms/zone.py:762
+#: forms/zone_template.py:118 forms/zone_template.py:163
+#: forms/zone_template.py:241 models/registrar.py:66 models/zone.py:188
+#: models/zone_template.py:46 tables/zone.py:48 tables/zone_template.py:25
+#: templates/netbox_dns/registrar.html:8
+#: templates/netbox_dns/zone/registration.html:10
+#: templates/netbox_dns/zonetemplate.html:58
+msgid "Registrar"
+msgstr ""
+
+#: filtersets/zone.py:101 filtersets/zone_template.py:58
+msgid "Registrant ID"
+msgstr ""
+
+#: filtersets/zone.py:107 filtersets/zone_template.py:64 forms/zone.py:447
+#: forms/zone.py:575 forms/zone.py:771 forms/zone_template.py:123
+#: forms/zone_template.py:172 forms/zone_template.py:246 models/zone.py:201
+#: models/zone_template.py:55 tables/zone.py:52 tables/zone_template.py:29
+#: templates/netbox_dns/zone/registration.html:18
+#: templates/netbox_dns/zonetemplate.html:62
+msgid "Registrant"
+msgstr ""
+
+#: filtersets/zone.py:111 filtersets/zone_template.py:68
+msgid "Administrative Contact ID"
+msgstr ""
+
+#: filtersets/zone.py:117 filtersets/zone_template.py:74 forms/zone.py:452
+#: forms/zone.py:585 forms/zone.py:776 forms/zone_template.py:128
+#: forms/zone_template.py:181 forms/zone_template.py:251
+#: models/zone_template.py:64 tables/zone.py:56 tables/zone_template.py:33
+#: templates/netbox_dns/zone/registration.html:22
+#: templates/netbox_dns/zonetemplate.html:66
+msgid "Administrative Contact"
+msgstr ""
+
+#: filtersets/zone.py:121 filtersets/zone_template.py:78
+msgid "Technical Contact ID"
+msgstr ""
+
+#: filtersets/zone.py:127 filtersets/zone_template.py:84 forms/zone.py:457
+#: forms/zone.py:595 forms/zone.py:781 forms/zone_template.py:133
+#: forms/zone_template.py:190 forms/zone_template.py:256 models/zone.py:218
+#: models/zone_template.py:73 tables/zone.py:60 tables/zone_template.py:37
+#: templates/netbox_dns/zone/registration.html:26
+#: templates/netbox_dns/zonetemplate.html:70
+msgid "Technical Contact"
+msgstr ""
+
+#: filtersets/zone.py:131 filtersets/zone_template.py:88
+msgid "Billing Contact ID"
+msgstr ""
+
+#: filtersets/zone.py:137 filtersets/zone_template.py:94 forms/zone.py:462
+#: forms/zone.py:605 forms/zone.py:786 forms/zone_template.py:138
+#: forms/zone_template.py:199 forms/zone_template.py:261 models/zone.py:227
+#: models/zone_template.py:82 tables/zone.py:64 tables/zone_template.py:41
+#: templates/netbox_dns/zone/registration.html:30
+#: templates/netbox_dns/zonetemplate.html:74
+msgid "Billing Contact"
+msgstr ""
+
+#: filtersets/zone.py:140
+msgid "Zone is active"
+msgstr ""
+
+#: filtersets/zone_template.py:26
+msgid "Record Template ID"
+msgstr ""
+
+#: filtersets/zone_template.py:32 forms/record_template.py:63
+#: models/record_template.py:93 templates/netbox_dns/recordtemplate.html:12
+#: templates/netbox_dns/zonetemplate.html:85
+msgid "Record Template"
+msgstr ""
+
+#: filtersets/zone_template.py:48
+msgid "Registrar ID"
+msgstr ""
+
+#: forms/nameserver.py:43 forms/nameserver.py:62 forms/nameserver.py:89
+#: forms/record.py:133 forms/record_template.py:115 forms/registrar.py:71
+#: forms/registration_contact.py:89 forms/registration_contact.py:173
+#: forms/zone.py:132 forms/zone.py:396 models/nameserver.py:33
+#: models/record.py:129 models/record_template.py:32 models/registrar.py:20
+#: models/registration_contact.py:27 models/view.py:31 models/zone.py:92
+#: tables/nameserver.py:15 tables/record.py:40 tables/record_template.py:19
+#: tables/registrar.py:14 tables/view.py:18 tables/zone.py:20
+#: tables/zone_template.py:18 templates/netbox_dns/nameserver.html:11
+#: templates/netbox_dns/record.html:43
+#: templates/netbox_dns/recordtemplate.html:19
+#: templates/netbox_dns/registrar.html:11
+#: templates/netbox_dns/registrationcontact.html:11
+#: templates/netbox_dns/view.html:11 templates/netbox_dns/zone.html:12
+#: templates/netbox_dns/zonetemplate.html:15
+msgid "Name"
+msgstr ""
+
+#: forms/nameserver.py:48 forms/nameserver.py:83 forms/record.py:87
+#: forms/record.py:123 forms/record.py:298 forms/record_template.py:65
+#: forms/record_template.py:101 forms/record_template.py:232 forms/view.py:132
+#: forms/view.py:179 forms/view.py:248 forms/zone.py:257 forms/zone.py:381
+#: forms/zone.py:831 forms/zone_template.py:60 forms/zone_template.py:95
+#: forms/zone_template.py:289
+msgid "Tenancy"
+msgstr ""
+
+#: forms/nameserver.py:49 forms/record.py:88 forms/record_template.py:66
+#: forms/registrar.py:39 forms/zone.py:256 forms/zone_template.py:59
+msgid "Tags"
+msgstr ""
+
+#: forms/nameserver.py:76 forms/nameserver.py:115 forms/record.py:160
+#: forms/record.py:279 forms/record_template.py:132
+#: forms/record_template.py:213 forms/registrar.py:79 forms/registrar.py:129
+#: forms/registration_contact.py:93 forms/registration_contact.py:177
+#: forms/view.py:235 forms/zone.py:157 forms/zone.py:405 forms/zone.py:699
+#: models/nameserver.py:38 models/record.py:184 models/record_template.py:36
+#: models/registrar.py:25 models/registration_contact.py:32 models/view.py:36
+#: models/zone_template.py:22 templates/netbox_dns/nameserver.html:22
+#: templates/netbox_dns/record.html:125
+#: templates/netbox_dns/recordtemplate.html:69
+#: templates/netbox_dns/registrar.html:16
+#: templates/netbox_dns/registrationcontact.html:16
+#: templates/netbox_dns/view.html:20 templates/netbox_dns/zone.html:33
+#: templates/netbox_dns/zone.html:93 templates/netbox_dns/zonetemplate.html:20
+#: templates/netbox_dns/zonetemplate.html:44
+msgid "Description"
+msgstr ""
+
+#: forms/nameserver.py:82 forms/nameserver.py:128 forms/record.py:121
+#: forms/record.py:296 forms/record_template.py:98 forms/record_template.py:230
+#: forms/registrar.py:58 forms/registrar.py:161
+#: forms/registration_contact.py:72 forms/registration_contact.py:225
+#: forms/view.py:177 forms/view.py:246 forms/zone.py:358 forms/zone.py:803
+#: forms/zone_template.py:85 forms/zone_template.py:275
+msgid "Attributes"
+msgstr ""
+
+#: forms/nameserver.py:95 forms/nameserver.py:120 forms/record.py:217
+#: forms/record.py:284 forms/record_template.py:165
+#: forms/record_template.py:218 forms/view.py:221 forms/view.py:240
+#: forms/zone.py:612 forms/zone.py:791 forms/zone_template.py:205
+#: forms/zone_template.py:266 templates/netbox_dns/nameserver.html:27
+#: templates/netbox_dns/record.html:62
+#: templates/netbox_dns/recordtemplate.html:30
+#: templates/netbox_dns/view.html:25 templates/netbox_dns/zone.html:38
+#: templates/netbox_dns/zonetemplate.html:25
+msgid "Tenant"
+msgstr ""
+
+#: forms/record.py:62 forms/record.py:156 forms/record.py:187
+#: forms/record.py:251 forms/zone.py:228 models/record.py:133
+#: models/zone.py:275 tables/record.py:28 templates/netbox_dns/record.html:53
+#: templates/netbox_dns/zone.html:9
+msgid "Zone"
+msgstr ""
+
+#: forms/record.py:67 forms/record.py:146 forms/record.py:211
+#: forms/record.py:274 forms/record_template.py:46 forms/record_template.py:128
+#: forms/record_template.py:159 forms/record_template.py:208
+#: models/record.py:179 models/record_template.py:60 tables/record.py:75
+#: tables/record_template.py:41 templates/netbox_dns/record.html:91
+#: templates/netbox_dns/recordtemplate.html:59
+msgid "Disable PTR"
+msgstr ""
+
+#: forms/record.py:71 forms/record.py:207 forms/record.py:269
+#: forms/record_template.py:50 forms/record_template.py:155
+#: forms/record_template.py:204 models/record.py:161
+#: models/record_template.py:55 tables/record.py:57
+#: tables/record_template.py:38 templates/netbox_dns/record.html:86
+#: templates/netbox_dns/recordtemplate.html:54
+#: templates/netbox_dns/zone.html:107
+msgid "TTL"
+msgstr ""
+
+#: forms/record.py:129 forms/record.py:198 forms/record.py:256
+#: forms/record_template.py:107 forms/record_template.py:146
+#: forms/record_template.py:191 models/record.py:145
+#: models/record_template.py:41 tables/record.py:37
+#: tables/record_template.py:26 templates/netbox_dns/record.html:72
+#: templates/netbox_dns/recordtemplate.html:40
+msgid "Type"
+msgstr ""
+
+#: forms/record.py:137 models/record.py:138 tables/record.py:44
+msgid "FQDN"
+msgstr ""
+
+#: forms/record.py:141 forms/record.py:260 forms/record_template.py:119
+#: forms/record_template.py:195 models/record.py:150
+#: models/record_template.py:45 tables/record.py:48
+#: tables/record_template.py:29 templates/netbox_dns/record.html:76
+#: templates/netbox_dns/recordtemplate.html:44
+msgid "Value"
+msgstr ""
+
+#: forms/record.py:151 forms/record.py:203 forms/record.py:265
+#: forms/record_template.py:124 forms/record_template.py:151
+#: forms/record_template.py:200 forms/zone.py:142 forms/zone.py:392
+#: forms/zone.py:480 forms/zone.py:684 models/record.py:154
+#: models/record_template.py:49 models/zone.py:96 tables/record.py:72
+#: tables/zone.py:32 templates/netbox_dns/recordtemplate.html:64
+#: templates/netbox_dns/zone.html:47
+msgid "Status"
+msgstr ""
+
+#: forms/record_template.py:100 forms/record_template.py:137 navigation.py:97
+#: templates/netbox_dns/recordtemplate.html:86
+msgid "Zone Templates"
+msgstr ""
+
+#: forms/record_template.py:111 forms/zone_template.py:100
+#: models/record_template.py:27 models/zone_template.py:17
+#: templates/netbox_dns/recordtemplate.html:15
+msgid "Template Name"
+msgstr ""
+
+#: forms/registrar.py:65 forms/registration_contact.py:41
+msgid "Contact"
+msgstr ""
+
+#: forms/registrar.py:75 forms/registrar.py:133
+#: forms/registration_contact.py:80 forms/registration_contact.py:233
+#: models/registrar.py:45 templates/netbox_dns/registrar.html:30
+msgid "Address"
+msgstr ""
+
+#: forms/registrar.py:83 forms/registrar.py:125 models/registrar.py:30
+#: templates/netbox_dns/registrar.html:21
+msgid "IANA ID"
+msgstr ""
+
+#: forms/registrar.py:87 forms/registrar.py:137 models/registrar.py:35
+#: templates/netbox_dns/registrar.html:34
+msgid "Referral URL"
+msgstr ""
+
+#: forms/registrar.py:91 forms/registrar.py:141 models/registrar.py:40
+#: templates/netbox_dns/registrar.html:38
+msgid "WHOIS Server"
+msgstr ""
+
+#: forms/registrar.py:95 forms/registrar.py:145 models/registrar.py:50
+#: templates/netbox_dns/registrar.html:42
+msgid "Abuse Email"
+msgstr ""
+
+#: forms/registrar.py:99 forms/registrar.py:149 models/registrar.py:54
+#: templates/netbox_dns/registrar.html:46
+msgid "Abuse Phone"
+msgstr ""
+
+#: forms/registration_contact.py:83 forms/registration_contact.py:241
+msgid "Communication"
+msgstr ""
+
+#: forms/registration_contact.py:97 models/registration_contact.py:22
+#: tables/registration_contact.py:14
+#: templates/netbox_dns/registrationcontact.html:21
+msgid "Contact ID"
+msgstr ""
+
+#: forms/registration_contact.py:101 forms/registration_contact.py:181
+#: models/registration_contact.py:37
+#: templates/netbox_dns/registrationcontact.html:25
+msgid "Organization"
+msgstr ""
+
+#: forms/registration_contact.py:105 forms/registration_contact.py:185
+#: models/registration_contact.py:42
+#: templates/netbox_dns/registrationcontact.html:29
+msgid "Street"
+msgstr ""
+
+#: forms/registration_contact.py:109 forms/registration_contact.py:189
+#: models/registration_contact.py:47
+#: templates/netbox_dns/registrationcontact.html:33
+msgid "City"
+msgstr ""
+
+#: forms/registration_contact.py:113 forms/registration_contact.py:193
+#: models/registration_contact.py:52
+#: templates/netbox_dns/registrationcontact.html:37
+msgid "State/Province"
+msgstr ""
+
+#: forms/registration_contact.py:117 forms/registration_contact.py:197
+#: models/registration_contact.py:57
+#: templates/netbox_dns/registrationcontact.html:41
+msgid "Postal Code"
+msgstr ""
+
+#: forms/registration_contact.py:121 forms/registration_contact.py:201
+#: templates/netbox_dns/registrationcontact.html:45
+msgid "Country"
+msgstr ""
+
+#: forms/registration_contact.py:125 forms/registration_contact.py:205
+#: models/registration_contact.py:67
+#: templates/netbox_dns/registrationcontact.html:49
+msgid "Phone"
+msgstr ""
+
+#: forms/registration_contact.py:129 forms/registration_contact.py:209
+#: models/registration_contact.py:72
+#: templates/netbox_dns/registrationcontact.html:53
+msgid "Phone Extension"
+msgstr ""
+
+#: forms/registration_contact.py:133 forms/registration_contact.py:213
+#: models/registration_contact.py:77
+#: templates/netbox_dns/registrationcontact.html:57
+msgid "Fax"
+msgstr ""
+
+#: forms/registration_contact.py:137 forms/registration_contact.py:217
+#: models/registration_contact.py:82
+#: templates/netbox_dns/registrationcontact.html:61
+msgid "Fax Extension"
+msgstr ""
+
+#: forms/registration_contact.py:141 forms/registration_contact.py:221
+msgid "Email Address"
+msgstr ""
+
+#: forms/view.py:112
+msgid "You do not have permission to modify assigned prefixes"
+msgstr ""
+
+#: forms/view.py:121 models/view.py:45 templates/netbox_dns/view.html:41
+msgid "IPAM Prefixes"
+msgstr ""
+
+#: forms/view.py:125
+msgid "Specify criteria for address record creation in JSON form"
+msgstr ""
+
+#: forms/view.py:126 models/view.py:51
+msgid "IP Address Filter"
+msgstr ""
+
+#: forms/view.py:161
+#, python-brace-format
+msgid "Invalid filter for IPAddress: {error}"
+msgstr ""
+
+#: forms/view.py:214
+msgid "Prefix IDs assigned to the view"
+msgstr ""
+
+#: forms/view.py:215
+msgid "Prefixes"
+msgstr ""
+
+#: forms/view.py:259
+msgid ""
+"Explicitly assigning DNS views overrides all inherited views for this prefix"
+msgstr ""
+
+#: forms/view.py:261 templates/netbox_dns/view/related.html:12
+msgid "Assigned DNS Views"
+msgstr ""
+
+#: forms/view.py:280
+msgid "You do not have permission to modify assigned views"
+msgstr ""
+
+#: forms/zone.py:137 forms/zone.py:618
+msgid "Template"
+msgstr ""
+
+#: forms/zone.py:151
+msgid "Default TTL for new records in this zone"
+msgstr ""
+
+#: forms/zone.py:153 forms/zone.py:490 forms/zone.py:694 models/zone.py:109
+#: templates/netbox_dns/zone.html:89
+msgid "Default TTL"
+msgstr ""
+
+#: forms/zone.py:161 forms/zone.py:494
+msgid "TTL for the SOA record of the zone"
+msgstr ""
+
+#: forms/zone.py:163 forms/zone.py:495 forms/zone.py:704 models/zone.py:114
+msgid "SOA TTL"
+msgstr ""
+
+#: forms/zone.py:167 forms/zone.py:509
+msgid "Mailbox of the zone's administrator"
+msgstr ""
+
+#: forms/zone.py:168 forms/zone.py:510 forms/zone.py:713 models/zone.py:128
+msgid "SOA RName"
+msgstr ""
+
+#: forms/zone.py:172 forms/zone.py:522
+msgid "Refresh interval for secondary nameservers"
+msgstr ""
+
+#: forms/zone.py:174 forms/zone.py:523 forms/zone.py:728 models/zone.py:140
+msgid "SOA Refresh"
+msgstr ""
+
+#: forms/zone.py:178 forms/zone.py:527
+msgid "Retry interval for secondary nameservers"
+msgstr ""
+
+#: forms/zone.py:180 forms/zone.py:528 forms/zone.py:733 models/zone.py:146
+msgid "SOA Retry"
+msgstr ""
+
+#: forms/zone.py:185 forms/zone.py:532
+msgid "Expire time after which the zone is considered unavailable"
+msgstr ""
+
+#: forms/zone.py:186 forms/zone.py:533 forms/zone.py:738 models/zone.py:152
+msgid "SOA Expire"
+msgstr ""
+
+#: forms/zone.py:190
+msgid "Minimum TTL for negative results, e.g. NXRRSET"
+msgstr ""
+
+#: forms/zone.py:192 forms/zone.py:538 forms/zone.py:743 models/zone.py:158
+msgid "SOA Minimum TTL"
+msgstr ""
+
+#: forms/zone.py:196 models/zone.py:165
+msgid "Automatically generate the SOA serial number"
+msgstr ""
+
+#: forms/zone.py:197 forms/zone.py:419 forms/zone.py:514 forms/zone.py:718
+#: models/zone.py:164
+msgid "Generate SOA Serial"
+msgstr ""
+
+#: forms/zone.py:202 forms/zone.py:518 forms/zone.py:723 models/zone.py:134
+msgid "SOA Serial"
+msgstr ""
+
+#: forms/zone.py:208 forms/zone.py:542 forms/zone.py:748 models/zone.py:237
+msgid "RFC2317 IPv4 prefix with a length of at least 25 bits"
+msgstr ""
+
+#: forms/zone.py:214 forms/zone.py:548 forms/zone.py:755
+msgid ""
+"IPv4 reverse zone for deletgating the RFC2317 PTR records is managed in "
+"NetBox DNS"
+msgstr ""
+
+#: forms/zone.py:216 forms/zone.py:550 forms/zone.py:757 models/zone.py:242
+msgid "RFC2317 Parent Managed"
+msgstr ""
+
+#: forms/zone.py:240 forms/zone.py:364 forms/zone.py:815
+msgid "SOA"
+msgstr ""
+
+#: forms/zone.py:245 forms/zone.py:370 forms/zone.py:820
+#: templates/netbox_dns/zone.html:149
+msgid "RFC2317"
+msgstr ""
+
+#: forms/zone.py:254 forms/zone.py:829 forms/zone_template.py:57
+#: forms/zone_template.py:287 navigation.py:198
+#: templates/netbox_dns/zone/registration.html:7
+#: templates/netbox_dns/zonetemplate.html:55
+msgid "Domain Registration"
+msgstr ""
+
+#: forms/zone.py:379 forms/zone_template.py:93
+msgid "Registration"
+msgstr ""
+
+#: forms/zone.py:410 templates/netbox_dns/zone.html:111
+msgid "MName"
+msgstr ""
+
+#: forms/zone.py:414 templates/netbox_dns/zone.html:115
+msgid "RName"
+msgstr ""
+
+#: forms/zone.py:428 templates/netbox_dns/zone.html:156
+msgid "Parent Managed"
+msgstr ""
+
+#: forms/zone.py:442 forms/zone.py:565 forms/zone.py:766 models/zone.py:194
+#: templates/netbox_dns/zone/registration.html:14
+msgid "Registry Domain ID"
+msgstr ""
+
+#: forms/zone.py:473
+msgid "View not found."
+msgstr ""
+
+#: forms/zone.py:475
+msgid "View"
+msgstr ""
+
+#: forms/zone.py:502
+msgid "Nameserver not found."
+msgstr ""
+
+#: forms/zone.py:537
+msgid "Minimum TTL for negative results, e.g. NXRRSET, NXDOMAIN"
+msgstr ""
+
+#: forms/zone.py:557 forms/zone_template.py:161
+msgid "Registrar not found."
+msgstr ""
+
+#: forms/zone.py:564
+msgid "Domain ID assigned by the registry"
+msgstr ""
+
+#: forms/zone.py:572 forms/zone_template.py:170
+msgid "Registrant contact ID not found"
+msgstr ""
+
+#: forms/zone.py:574
+msgid "Owner of the domain"
+msgstr ""
+
+#: forms/zone.py:583 forms/zone_template.py:179
+msgid "Administrative contact ID not found"
+msgstr ""
+
+#: forms/zone.py:593 forms/zone_template.py:188
+msgid "Technical contact ID not found"
+msgstr ""
+
+#: forms/zone.py:603 forms/zone_template.py:197
+msgid "Billing contact ID not found"
+msgstr ""
+
+#: forms/zone.py:611
+msgid "Assigned tenant"
+msgstr ""
+
+#: forms/zone_template.py:50 forms/zone_template.py:86
+#: forms/zone_template.py:110 forms/zone_template.py:235
+#: forms/zone_template.py:279 models/record_template.py:94
+#: models/zone_template.py:33 navigation.py:117
+#: templates/netbox_dns/zonetemplate.html:87
+msgid "Record Templates"
+msgstr ""
+
+#: forms/zone_template.py:154
+msgid "Record Remplates"
+msgstr ""
+
+#: models/record.py:166
+msgid "Managed"
+msgstr ""
+
+#: models/record.py:180 models/record_template.py:61
+msgid "Disable PTR record creation"
+msgstr ""
+
+#: models/record.py:196 tables/record.py:112
+msgid "Related IP Address"
+msgstr ""
+
+#: models/record.py:197
+msgid "IP address related to an address (A/AAAA) or PTR record"
+msgstr ""
+
+#: models/record.py:210
+msgid "RFC2317 CNAME Record"
+msgstr ""
+
+#: models/record.py:233 templates/netbox_dns/record.html:40
+msgid "Record"
+msgstr ""
+
+#: models/record.py:234 navigation.py:71 views/zone.py:132
+msgid "Records"
+msgstr ""
+
+#: models/record.py:549
+#, python-brace-format
+msgid "{name} is not a name in {zone}"
+msgstr ""
+
+#: models/record.py:636
+#, python-brace-format
+msgid ""
+"There is already an active {type} record for name {name} in zone {zone} with "
+"value {value}."
+msgstr ""
+
+#: models/record.py:699
+#, python-brace-format
+msgid ""
+"There is at least one active {type} record for name {name} in zone {zone} "
+"and TTL is different ({ttls})."
+msgstr ""
+
+#: models/record.py:786
+#, python-brace-format
+msgid ""
+"There is already an active record for name {name} in zone {zone}, RFC2317 "
+"CNAME is not allowed."
+msgstr ""
+
+#: models/record.py:795
+msgid ""
+"SOA records are only allowed with name @ and are created automatically by "
+"NetBox DNS"
+msgstr ""
+
+#: models/record.py:805
+#, python-brace-format
+msgid ""
+"There is already an active record for name {name} in zone {zone}, CNAME is "
+"not allowed."
+msgstr ""
+
+#: models/record.py:817
+#, python-brace-format
+msgid ""
+"There is already an active CNAME record for name {name} in zone {zone}, no "
+"other record allowed."
+msgstr ""
+
+#: models/record.py:827
+#, python-brace-format
+msgid ""
+"There is already an active {type} record for name {name} in zone {zone}, "
+"more than one are not allowed."
+msgstr ""
+
+#: models/record_template.py:163
+#, python-brace-format
+msgid "Error while processing record template {template}: {error}"
+msgstr ""
+
+#: models/registrar.py:67 navigation.py:137
+msgid "Registrars"
+msgstr ""
+
+#: models/registration_contact.py:62
+msgid "Country (ISO 3166)"
+msgstr ""
+
+#: models/registration_contact.py:87
+#: templates/netbox_dns/registrationcontact.html:65
+msgid "Email"
+msgstr ""
+
+#: models/registration_contact.py:123
+#: templates/netbox_dns/registrationcontact.html:8
+msgid "Registration Contact"
+msgstr ""
+
+#: models/registration_contact.py:124 navigation.py:157
+msgid "Registration Contacts"
+msgstr ""
+
+#: models/view.py:41 tables/view.py:22 templates/netbox_dns/view.html:15
+msgid "Default View"
+msgstr ""
+
+#: models/view.py:87 models/view.py:89
+msgid "The default view cannot be deleted"
+msgstr ""
+
+#: models/view.py:105
+msgid "Please select a different view as default view to change this setting!"
+msgstr ""
+
+#: models/zone.py:174
+msgid "Network related to a reverse lookup zone (.arpa)"
+msgstr ""
+
+#: models/zone.py:195
+msgid "ID of the domain assigned by the registry"
+msgstr ""
+
+#: models/zone.py:243
+msgid "The parent zone for the RFC2317 zone is managed by NetBox DNS"
+msgstr ""
+
+#: models/zone.py:251
+msgid "Parent zone for RFC2317 reverse zones"
+msgstr ""
+
+#: models/zone.py:463
+#, python-brace-format
+msgid "No nameservers are configured for zone {zone}"
+msgstr ""
+
+#: models/zone.py:489
+#, python-brace-format
+msgid ""
+"Nameserver {nameserver} does not have an active address record in zone {zone}"
+msgstr ""
+
+#: models/zone.py:506
+#, python-brace-format
+msgid "soa_serial must not decrease for zone {zone}."
+msgstr ""
+
+#: models/zone.py:619
+#, python-brace-format
+msgid "Default soa_mname instance {nameserver} does not exist"
+msgstr ""
+
+#: models/zone.py:649
+msgid "soa_rname not set and no default value defined"
+msgstr ""
+
+#: models/zone.py:665
+#, python-brace-format
+msgid ""
+"soa_serial is not defined and soa_serial_auto is disabled for zone {zone}."
+msgstr ""
+
+#: models/zone.py:685
+#, python-brace-format
+msgid "Enabling soa_serial_auto would decrease soa_serial for zone {zone}."
+msgstr ""
+
+#: models/zone.py:721
+msgid "A regular reverse zone can not be used as an RFC2317 zone."
+msgstr ""
+
+#: models/zone.py:733
+#, python-brace-format
+msgid "Parent zone not found in view {view}."
+msgstr ""
+
+#: models/zone.py:752
+#, python-brace-format
+msgid "RFC2317 prefix overlaps with zone {zone}."
+msgstr ""
+
+#: models/zone_template.py:59
+msgid "Registrar of the domain"
+msgstr ""
+
+#: navigation.py:11
+msgid "Views"
+msgstr ""
+
+#: navigation.py:16 navigation.py:36 navigation.py:56 navigation.py:76
+#: navigation.py:102 navigation.py:122 navigation.py:142 navigation.py:162
+msgid "Add"
+msgstr ""
+
+#: navigation.py:22 navigation.py:42 navigation.py:62 navigation.py:82
+#: navigation.py:108 navigation.py:128 navigation.py:148 navigation.py:168
+msgid "Import"
+msgstr ""
+
+#: navigation.py:91 templates/netbox_dns/record.html:18
+#: templates/netbox_dns/record/managed.html:4 views/zone.py:154
+msgid "Managed Records"
+msgstr ""
+
+#: navigation.py:181
+msgid "DNS Configuration"
+msgstr ""
+
+#: navigation.py:191
+msgid "Templates"
+msgstr ""
+
+#: signals/ipam_dnssync.py:65
+#, python-brace-format
+msgid ""
+"Unique DNS records are enforced and there is already an active IP address "
+"{address} with DNS name {name}. Plesase choose a different name or disable "
+"record creation for this IP address."
+msgstr ""
+
+#: signals/ipam_dnssync.py:100
+msgid "You do not have permission to alter DNSsync custom fields"
+msgstr ""
+
+#: signals/ipam_dnssync.py:144
+#, python-brace-format
+msgid ""
+"This prefix is currently assigned to the following DNS views: {views}. "
+"Please deassign it from these views before making changes to the prefix or "
+"VRF."
+msgstr ""
+
+#: signals/ipam_dnssync.py:152
+#, python-brace-format
+msgid ""
+"Prefix is assigned to DNS views {views}. Prefix and VRF must not be changed"
+msgstr ""
+
+#: signals/ipam_dnssync.py:175
+#, python-brace-format
+msgid ""
+"Prefix deletion would cause DNS errors: {errors}. Please review DNS View "
+"assignments for this and the parent prefix"
+msgstr ""
+
+#: tables/ipam_dnssync.py:8 templates/netbox_dns/view/button.html:7
+msgid "DNS Views"
+msgstr ""
+
+#: tables/record.py:52 tables/record_template.py:33
+#: templates/netbox_dns/record.html:81
+#: templates/netbox_dns/recordtemplate.html:49
+msgid "Unicode Value"
+msgstr ""
+
+#: tables/record.py:81 templates/netbox_dns/record.html:97
+msgid "PTR Record"
+msgstr ""
+
+#: tables/record_template.py:23
+msgid "Record Name"
+msgstr ""
+
+#: templates/netbox_dns/nameserver.html:16 templates/netbox_dns/record.html:48
+#: templates/netbox_dns/recordtemplate.html:24
+#: templates/netbox_dns/zone.html:17
+msgid "IDN"
+msgstr ""
+
+#: templates/netbox_dns/record.html:134
+msgid "CNAME Target"
+msgstr ""
+
+#: templates/netbox_dns/record.html:136
+msgid "CNAME Targets"
+msgstr ""
+
+#: templates/netbox_dns/record.html:145
+msgid "CNAME"
+msgstr ""
+
+#: templates/netbox_dns/record.html:147
+msgid "CNAMEs"
+msgstr ""
+
+#: templates/netbox_dns/record/related.html:9
+msgid "Related DNS Address Record"
+msgstr ""
+
+#: templates/netbox_dns/record/related.html:11
+msgid "Related DNS Address Records"
+msgstr ""
+
+#: templates/netbox_dns/record/related.html:21
+msgid "Related DNS Pointer Record"
+msgstr ""
+
+#: templates/netbox_dns/record/related.html:23
+msgid "Related DNS Pointer Records"
+msgstr ""
+
+#: templates/netbox_dns/registrar.html:27
+msgid "Contact Details"
+msgstr ""
+
+#: templates/netbox_dns/view.html:8 templates/netbox_dns/zone.html:28
+msgctxt "DNS"
+msgid "View"
+msgstr ""
+
+#: templates/netbox_dns/view.html:55
+msgid "Global"
+msgstr ""
+
+#: templates/netbox_dns/view.html:60
+msgid "No prefixes assigned"
+msgstr ""
+
+#: templates/netbox_dns/view.html:66
+msgid "IP Address Filters"
+msgstr ""
+
+#: templates/netbox_dns/view.html:71
+msgid "No filters defined"
+msgstr ""
+
+#: templates/netbox_dns/view/prefix.html:5
+#, python-format
+msgid "Configure DNS views for %(type)s %(name)s %(vrf)s"
+msgstr ""
+
+#: templates/netbox_dns/view/prefix.html:20
+msgid "Views inherited from prefix"
+msgstr ""
+
+#: templates/netbox_dns/view/prefix.html:34
+msgid "Cancel"
+msgstr ""
+
+#: templates/netbox_dns/view/prefix.html:35
+msgid "Save"
+msgstr ""
+
+#: templates/netbox_dns/view/related.html:10
+msgid "Assigned DNS View"
+msgstr ""
+
+#: templates/netbox_dns/view/related.html:23
+msgid "Inherited DNS View"
+msgstr ""
+
+#: templates/netbox_dns/view/related.html:25
+msgid "Inherited DNS Views"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:61
+msgid "Warnings"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:75
+msgid "Errors"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:104
+msgid "Zone SOA"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:120
+msgid "Serial (auto-generated)"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:125
+msgctxt "SOA"
+msgid "Serial"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:130
+msgid "Refresh"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:134
+msgid "Retry"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:138
+msgid "Expire"
+msgstr ""
+
+#: templates/netbox_dns/zone.html:142
+msgid "Minimum TTL"
+msgstr ""
+
+#: templates/netbox_dns/zone/base.html:12
+msgid "Add Record"
+msgstr ""
+
+#: templates/netbox_dns/zone/child.html:27
+#: templates/netbox_dns/zone/record.html:27
+msgid "Edit Selected"
+msgstr ""
+
+#: templates/netbox_dns/zone/child.html:32
+#: templates/netbox_dns/zone/record.html:32
+msgid "Delete Selected"
+msgstr ""
+
+#: validators/dns_name.py:60
+#, python-brace-format
+msgid "{name} is not a valid fully qualified DNS host name"
+msgstr ""
+
+#: validators/dns_name.py:69
+#, python-brace-format
+msgid "{name} is not a valid RName"
+msgstr ""
+
+#: validators/dns_name.py:83
+#, python-brace-format
+msgid "{name} is not a valid DNS host name"
+msgstr ""
+
+#: validators/dns_name.py:106
+#, python-brace-format
+msgid "{name} is not a valid DNS domain name"
+msgstr ""
+
+#: validators/dns_value.py:34
+#, python-brace-format
+msgid "Record value {value} is not a valid value for a {type} record: {error}."
+msgstr ""
+
+#: validators/rfc2317.py:15
+#, python-brace-format
+msgid "{prefix} is not a valid prefix. Did you mean {cidr}?"
+msgstr ""
+
+#: validators/rfc2317.py:23
+msgid "RFC2317 requires an IPv4 prefix."
+msgstr ""
+
+#: validators/rfc2317.py:28
+msgid "RFC2317 requires at least 25 bit prefix length."
+msgstr ""
+
+#: views/zone.py:175
+msgid "RFC2317 Child Zones"
+msgstr ""
+
+#: views/zone.py:194
+msgid "Child Zones"
+msgstr ""

--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
@@ -29,10 +30,12 @@ __all__ = (
 
 class NameServer(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     name = models.CharField(
+        verbose_name=_("Name"),
         unique=True,
         max_length=255,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         max_length=200,
         blank=True,
     )
@@ -50,8 +53,8 @@ class NameServer(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     )
 
     class Meta:
-        verbose_name = "Nameserver"
-        verbose_name_plural = "Nameservers"
+        verbose_name = _("Nameserver")
+        verbose_name_plural = _("Nameservers")
 
         ordering = ("name",)
 

--- a/netbox_dns/models/record_template.py
+++ b/netbox_dns/models/record_template.py
@@ -4,6 +4,7 @@ from dns import name as dns_name
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
@@ -23,37 +24,41 @@ __all__ = (
 
 class RecordTemplate(NetBoxModel):
     name = models.CharField(
-        verbose_name="Template name",
+        verbose_name=_("Template Name"),
         unique=True,
         max_length=200,
     )
     record_name = models.CharField(
-        verbose_name="Name",
+        verbose_name=_("Name"),
         max_length=255,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         max_length=200,
         blank=True,
     )
     type = models.CharField(
+        verbose_name=_("Type"),
         choices=RecordTypeChoices,
     )
     value = models.CharField(
+        verbose_name=_("Value"),
         max_length=65535,
     )
     status = models.CharField(
+        verbose_name=_("Status"),
         choices=RecordStatusChoices,
         default=RecordStatusChoices.STATUS_ACTIVE,
         blank=False,
     )
     ttl = models.PositiveIntegerField(
-        verbose_name="TTL",
+        verbose_name=_("TTL"),
         null=True,
         blank=True,
     )
     disable_ptr = models.BooleanField(
-        verbose_name="Disable PTR",
-        help_text="Disable PTR record creation",
+        verbose_name=_("Disable PTR"),
+        help_text=_("Disable PTR record creation"),
         default=False,
     )
     tenant = models.ForeignKey(
@@ -85,8 +90,8 @@ class RecordTemplate(NetBoxModel):
     )
 
     class Meta:
-        verbose_name = "Record Template"
-        verbose_name_plural = "Record Templates"
+        verbose_name = _("Record Template")
+        verbose_name_plural = _("Record Templates")
 
         ordering = ("name",)
 
@@ -155,7 +160,9 @@ class RecordTemplate(NetBoxModel):
             record = Record.objects.create(**record_data)
         except ValidationError as exc:
             raise ValidationError(
-                f"Error while processing record template {self}: {exc.messages[0]}"
+                _("Error while processing record template {template}: {error}").format(
+                    template=self, error=exc.messages[0]
+                )
             )
 
         if tags := self.tags.all():

--- a/netbox_dns/models/registrar.py
+++ b/netbox_dns/models/registrar.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
@@ -16,38 +17,41 @@ class Registrar(NetBoxModel):
     # Data fields according to https://www.icann.org/resources/pages/rdds-labeling-policy-2017-02-01-en
     # -
     name = models.CharField(
+        verbose_name=_("Name"),
         unique=True,
         max_length=255,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         blank=True,
         max_length=200,
     )
     iana_id = models.IntegerField(
-        verbose_name="IANA ID",
+        verbose_name=_("IANA ID"),
         null=True,
         blank=True,
     )
     referral_url = models.URLField(
-        verbose_name="Referral URL",
+        verbose_name=_("Referral URL"),
         max_length=255,
         blank=True,
     )
     whois_server = models.CharField(
-        verbose_name="WHOIS Server",
+        verbose_name=_("WHOIS Server"),
         max_length=255,
         blank=True,
     )
     address = models.CharField(
+        verbose_name=_("Address"),
         max_length=200,
         blank=True,
     )
     abuse_email = models.EmailField(
-        verbose_name="Abuse Email",
+        verbose_name=_("Abuse Email"),
         blank=True,
     )
     abuse_phone = models.CharField(
-        verbose_name="Abuse Phone",
+        verbose_name=_("Abuse Phone"),
         max_length=50,
         blank=True,
     )
@@ -59,8 +63,8 @@ class Registrar(NetBoxModel):
         return str(self.name)
 
     class Meta:
-        verbose_name = "Registrar"
-        verbose_name_plural = "Registrars"
+        verbose_name = _("Registrar")
+        verbose_name_plural = _("Registrars")
 
         ordering = (
             "name",

--- a/netbox_dns/models/registration_contact.py
+++ b/netbox_dns/models/registration_contact.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
@@ -18,67 +19,72 @@ class RegistrationContact(NetBoxModel):
     # Data fields according to https://www.icann.org/resources/pages/rdds-labeling-policy-2017-02-01-en
     # -
     contact_id = models.CharField(
-        verbose_name="Contact ID",
+        verbose_name=_("Contact ID"),
         max_length=50,
         unique=True,
     )
     name = models.CharField(
+        verbose_name=_("Name"),
         blank=True,
         max_length=100,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         blank=True,
         max_length=200,
     )
     organization = models.CharField(
+        verbose_name=_("Organization"),
         blank=True,
         max_length=200,
     )
     street = models.CharField(
+        verbose_name=_("Street"),
         blank=True,
         max_length=50,
     )
     city = models.CharField(
+        verbose_name=_("City"),
         blank=True,
         max_length=50,
     )
     state_province = models.CharField(
-        verbose_name="State/Province",
+        verbose_name=_("State/Province"),
         blank=True,
         max_length=255,
     )
     postal_code = models.CharField(
-        verbose_name="Postal Code",
+        verbose_name=_("Postal Code"),
         blank=True,
         max_length=20,
     )
     country = models.CharField(
-        verbose_name="Country (ISO 3166)",
+        verbose_name=_("Country (ISO 3166)"),
         blank=True,
         max_length=2,
     )
     phone = models.CharField(
-        verbose_name="Phone",
+        verbose_name=_("Phone"),
         blank=True,
         max_length=50,
     )
     phone_ext = models.CharField(
-        verbose_name="Phone Extension",
+        verbose_name=_("Phone Extension"),
         blank=True,
         max_length=50,
     )
     fax = models.CharField(
-        verbose_name="Fax",
+        verbose_name=_("Fax"),
         blank=True,
         max_length=50,
     )
     fax_ext = models.CharField(
-        verbose_name="Fax Extension",
+        verbose_name=_("Fax Extension"),
         blank=True,
         max_length=50,
     )
     email = models.EmailField(
-        verbose_name="Email",
+        verbose_name=_("Email"),
         blank=True,
     )
 
@@ -114,8 +120,8 @@ class RegistrationContact(NetBoxModel):
         return self.contact_id
 
     class Meta:
-        verbose_name = "Registration Contact"
-        verbose_name_plural = "Registration Contacts"
+        verbose_name = _("Registration Contact")
+        verbose_name_plural = _("Registration Contacts")
 
         ordering = (
             "name",

--- a/netbox_dns/models/view.py
+++ b/netbox_dns/models/view.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.urls import reverse
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 from netbox.models import NetBoxModel
 from netbox.models.features import ContactsMixin
@@ -26,23 +28,27 @@ __all__ = (
 
 class View(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     name = models.CharField(
+        verbose_name=_("Name"),
         unique=True,
         max_length=255,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         max_length=200,
         blank=True,
     )
     default_view = models.BooleanField(
+        verbose_name=_("Default View"),
         default=False,
     )
     prefixes = models.ManyToManyField(
+        verbose_name=_("IPAM Prefixes"),
         to="ipam.Prefix",
         related_name="netbox_dns_views",
         blank=True,
     )
     ip_address_filter = models.JSONField(
-        verbose_name="IP Address Filter",
+        verbose_name=_("IP Address Filter"),
         blank=True,
         null=True,
     )
@@ -70,17 +76,17 @@ class View(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         return str(self.name)
 
     class Meta:
-        verbose_name = "View"
-        verbose_name_plural = "Views"
+        verbose_name = _p("DNS", "View")
+        verbose_name_plural = _p("DNS", "Views")
 
         ordering = ("name",)
 
     def delete(self, *args, **kwargs):
         if self.default_view:
             if current_request.get() is not None:
-                raise AbortRequest("The default view cannot be deleted")
+                raise AbortRequest(_("The default view cannot be deleted"))
 
-            raise ValidationError("The default view cannot be deleted")
+            raise ValidationError(_("The default view cannot be deleted"))
 
         super().delete(*args, **kwargs)
 
@@ -95,7 +101,9 @@ class View(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         ):
             raise ValidationError(
                 {
-                    "default_view": "Please select a different view as default view to change this setting!"
+                    "default_view": _(
+                        "Please select a different view as default view to change this setting!"
+                    )
                 }
             )
 

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -16,6 +16,8 @@ from django.urls import reverse
 from django.db.models.signals import m2m_changed
 from django.dispatch import receiver
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 from netbox.models import NetBoxModel
 from netbox.models.features import ContactsMixin
@@ -81,82 +83,86 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         self._ip_addresses_checked = False
 
     view = models.ForeignKey(
+        verbose_name=_p("DNS", "View"),
         to="View",
         on_delete=models.PROTECT,
         null=False,
     )
     name = models.CharField(
+        verbose_name=_("Name"),
         max_length=255,
     )
     status = models.CharField(
+        verbose_name=_("Status"),
         max_length=50,
         choices=ZoneStatusChoices,
         default=ZoneStatusChoices.STATUS_ACTIVE,
         blank=True,
     )
     nameservers = models.ManyToManyField(
+        verbose_name=_("Nameserver"),
         to="NameServer",
         related_name="zones",
         blank=True,
     )
     default_ttl = models.PositiveIntegerField(
+        verbose_name=_("Default TTL"),
         blank=True,
-        verbose_name="Default TTL",
         validators=[MinValueValidator(1)],
     )
     soa_ttl = models.PositiveIntegerField(
+        verbose_name=_("SOA TTL"),
         blank=False,
         null=False,
-        verbose_name="SOA TTL",
         validators=[MinValueValidator(1)],
     )
     soa_mname = models.ForeignKey(
+        verbose_name=_("SOA MName"),
         to="NameServer",
         related_name="zones_soa",
-        verbose_name="SOA MName",
         on_delete=models.PROTECT,
         blank=False,
         null=False,
     )
     soa_rname = models.CharField(
+        verbose_name=_("SOA RName"),
         max_length=255,
         blank=False,
         null=False,
-        verbose_name="SOA RName",
     )
     soa_serial = models.BigIntegerField(
+        verbose_name=_("SOA Serial"),
         blank=True,
         null=True,
-        verbose_name="SOA Serial",
         validators=[MinValueValidator(1), MaxValueValidator(4294967295)],
     )
     soa_refresh = models.PositiveIntegerField(
+        verbose_name=_("SOA Refresh"),
         blank=False,
         null=False,
-        verbose_name="SOA Refresh",
         validators=[MinValueValidator(1)],
     )
     soa_retry = models.PositiveIntegerField(
+        verbose_name=_("SOA Retry"),
         blank=False,
         null=False,
-        verbose_name="SOA Retry",
         validators=[MinValueValidator(1)],
     )
     soa_expire = models.PositiveIntegerField(
+        verbose_name=_("SOA Expire"),
         blank=False,
         null=False,
-        verbose_name="SOA Expire",
         validators=[MinValueValidator(1)],
     )
     soa_minimum = models.PositiveIntegerField(
+        verbose_name=_("SOA Minimum TTL"),
         blank=False,
         null=False,
-        verbose_name="SOA Minimum TTL",
         validators=[MinValueValidator(1)],
     )
     soa_serial_auto = models.BooleanField(
-        verbose_name="Generate SOA Serial",
-        help_text="Automatically generate the SOA Serial field",
+        verbose_name=_("Generate SOA Serial"),
+        help_text=_("Automatically generate the SOA serial number"),
         default=True,
     )
     description = models.CharField(
@@ -164,8 +170,8 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         blank=True,
     )
     arpa_network = NetworkField(
-        verbose_name="ARPA Network",
-        help_text="Network related to a reverse lookup zone (.arpa)",
+        verbose_name=_("ARPA Network"),
+        help_text=_("Network related to a reverse lookup zone (.arpa)"),
         blank=True,
         null=True,
     )
@@ -179,70 +185,70 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     registrar = models.ForeignKey(
         to="Registrar",
         on_delete=models.SET_NULL,
-        verbose_name="Registrar",
-        help_text="The external registrar the domain is registered with",
+        verbose_name=_("Registrar"),
+        help_text=_("Registrar the domain is registered with"),
         blank=True,
         null=True,
     )
     registry_domain_id = models.CharField(
-        verbose_name="Registry Domain ID",
-        help_text="The ID of the domain assigned by the registry",
+        verbose_name=_("Registry Domain ID"),
+        help_text=_("ID of the domain assigned by the registry"),
         max_length=50,
         blank=True,
         null=True,
     )
     registrant = models.ForeignKey(
+        verbose_name=_("Registrant"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Registrant",
-        help_text="The owner of the domain",
+        help_text=_("Registrant of the domain"),
         blank=True,
         null=True,
     )
     admin_c = models.ForeignKey(
+        verbose_name="Administrative Contact",
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Admin Contact",
         related_name="admin_c_zones",
-        help_text="The administrative contact for the domain",
+        help_text=_("Administrative contact for the domain"),
         blank=True,
         null=True,
     )
     tech_c = models.ForeignKey(
+        verbose_name=_("Technical Contact"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Technical Contact",
         related_name="tech_c_zones",
-        help_text="The technical contact for the domain",
+        help_text=_("Technical contact for the domain"),
         blank=True,
         null=True,
     )
     billing_c = models.ForeignKey(
+        verbose_name=_("Billing Contact"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Billing Contact",
         related_name="billing_c_zones",
-        help_text="The billing contact for the domain",
+        help_text=_("Billing contact for the domain"),
         blank=True,
         null=True,
     )
     rfc2317_prefix = RFC2317NetworkField(
-        verbose_name="RCF2317 Prefix",
-        help_text="RFC2317 IPv4 prefix prefix with a length of at least 25 bits",
+        verbose_name=_("RFC2317 Prefix"),
+        help_text=_("RFC2317 IPv4 prefix with a length of at least 25 bits"),
         blank=True,
         null=True,
     )
     rfc2317_parent_managed = models.BooleanField(
-        verbose_name="RFC2317 Parent Managed",
-        help_text="The parent zone for the RFC2317 zone is managed by NetBox DNS",
+        verbose_name=_("RFC2317 Parent Managed"),
+        help_text=_("The parent zone for the RFC2317 zone is managed by NetBox DNS"),
         default=False,
     )
     rfc2317_parent_zone = models.ForeignKey(
+        verbose_name=_("RFC2317 Parent Zone"),
         to="self",
         on_delete=models.SET_NULL,
-        verbose_name="RFC2317 Parent Zone",
         related_name="rfc2317_child_zones",
-        help_text="Parent zone for RFC2317 reverse zones",
+        help_text=_("Parent zone for RFC2317 reverse zones"),
         blank=True,
         null=True,
     )
@@ -266,8 +272,8 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     )
 
     class Meta:
-        verbose_name = "Zone"
-        verbose_name_plural = "Zones"
+        verbose_name = _("Zone")
+        verbose_name_plural = _("Zones")
 
         ordering = (
             "view",
@@ -453,7 +459,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         ns_errors = []
 
         if not nameservers:
-            ns_errors.append(f"No nameservers are configured for zone {self}")
+            ns_errors.append(
+                _("No nameservers are configured for zone {zone}").format(zone=self)
+            )
 
         for _nameserver in nameservers:
             name = dns_name.from_text(_nameserver.name, origin=None)
@@ -477,7 +485,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
             if not address_records:
                 ns_warnings.append(
-                    f"Nameserver {_nameserver.name} does not have an active address record in zone {ns_zone}"
+                    _(
+                        "Nameserver {nameserver} does not have an active address record in zone {zone}"
+                    ).format(nameserver=_nameserver.name, zone=ns_zone)
                 )
 
         return ns_warnings, ns_errors
@@ -491,7 +501,11 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
         if (new_serial - old_serial) % SOA_SERIAL_WRAP > MAX_SOA_SERIAL_INCREMENT:
             raise ValidationError(
-                {"soa_serial": f"soa_serial must not decrease for zone {self.name}."}
+                {
+                    "soa_serial": _(
+                        "soa_serial must not decrease for zone {zone}."
+                    ).format(zone=self.name)
+                }
             )
 
     def get_auto_serial(self):
@@ -602,7 +616,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
                 self.soa_mname = NameServer.objects.get(name=default_soa_mname)
             except NameServer.DoesNotExist:
                 raise ValidationError(
-                    f"Default soa_mname instance {default_soa_mname} does not exist"
+                    _("Default soa_mname instance {nameserver} does not exist").format(
+                        nameserver=default_soa_mname
+                    )
                 )
 
         super().clean_fields(exclude=exclude)
@@ -630,7 +646,7 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
             ) from None
 
         if self.soa_rname in (None, ""):
-            raise ValidationError("soa_rname not set and no default value defined")
+            raise ValidationError(_("soa_rname not set and no default value defined"))
         try:
             dns_name.from_text(self.soa_rname, origin=dns_name.root)
             validate_rname(self.soa_rname)
@@ -645,7 +661,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
             if self.soa_serial is None:
                 raise ValidationError(
                     {
-                        "soa_serial": f"soa_serial is not defined and soa_serial_auto is disabled for zone {self.name}."
+                        "soa_serial": _(
+                            "soa_serial is not defined and soa_serial_auto is disabled for zone {zone}."
+                        ).format(zone=self.name)
                     }
                 )
 
@@ -663,7 +681,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
                 except ValidationError:
                     raise ValidationError(
                         {
-                            "soa_serial_auto": f"Enabling soa_serial_auto would decrease soa_serial for zone {self.name}."
+                            "soa_serial_auto": _(
+                                "Enabling soa_serial_auto would decrease soa_serial for zone {zone}."
+                            ).format(zone=self.name)
                         }
                     )
 
@@ -697,7 +717,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
             if self.arpa_network is not None:
                 raise ValidationError(
                     {
-                        "rfc2317_prefix": "A regular reverse zone can not be used as an RFC2317 zone."
+                        "rfc2317_prefix": _(
+                            "A regular reverse zone can not be used as an RFC2317 zone."
+                        )
                     }
                 )
 
@@ -707,7 +729,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
                 if rfc2317_parent_zone is None:
                     raise ValidationError(
                         {
-                            "rfc2317_parent_managed": f"Parent zone not found in view {self.view}."
+                            "rfc2317_parent_managed": _(
+                                "Parent zone not found in view {view}."
+                            ).format(view=self.view)
                         }
                     )
 
@@ -724,7 +748,9 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
             if overlapping_zones.exists():
                 raise ValidationError(
                     {
-                        "rfc2317_prefix": f"RFC2317 prefix overlaps with zone {overlapping_zones.first()}."
+                        "rfc2317_prefix": _(
+                            "RFC2317 prefix overlaps with zone {zone}."
+                        ).format(zone=overlapping_zones.first())
                     }
                 )
 

--- a/netbox_dns/models/zone_template.py
+++ b/netbox_dns/models/zone_template.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from netbox.models import NetBoxModel
 from netbox.search import SearchIndex, register_search
@@ -13,20 +14,23 @@ __all__ = (
 
 class ZoneTemplate(NetBoxModel):
     name = models.CharField(
-        verbose_name="Template name",
+        verbose_name=_("Template Name"),
         unique=True,
         max_length=200,
     )
     description = models.CharField(
+        verbose_name=_("Description"),
         max_length=200,
         blank=True,
     )
     nameservers = models.ManyToManyField(
+        verbose_name=_("Nameservers"),
         to="NameServer",
         related_name="+",
         blank=True,
     )
     record_templates = models.ManyToManyField(
+        verbose_name=_("Record Templates"),
         to="RecordTemplate",
         related_name="zone_templates",
         blank=True,
@@ -39,45 +43,47 @@ class ZoneTemplate(NetBoxModel):
         null=True,
     )
     registrar = models.ForeignKey(
+        verbose_name=_("Registrar"),
         to="Registrar",
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text="The external registrar the domain is registered with",
+        help_text=_("Registrar the domain is registered with"),
         blank=True,
         null=True,
     )
     registrant = models.ForeignKey(
+        verbose_name=_("Registrant"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text="The owner of the domain",
+        help_text=_("Registrar of the domain"),
         blank=True,
         null=True,
     )
     admin_c = models.ForeignKey(
+        verbose_name=_("Administrative Contact"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Admin contact",
         related_name="+",
-        help_text="The administrative contact for the domain",
+        help_text=_("Administrative contact for the domain"),
         blank=True,
         null=True,
     )
     tech_c = models.ForeignKey(
+        verbose_name=_("Technical Contact"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Tech contact",
         related_name="+",
-        help_text="The technical contact for the domain",
+        help_text=_("Technical contact for the domain"),
         blank=True,
         null=True,
     )
     billing_c = models.ForeignKey(
+        verbose_name=_("Billing Contact"),
         to="RegistrationContact",
         on_delete=models.SET_NULL,
-        verbose_name="Billing contact",
         related_name="+",
-        help_text="The billing contact for the domain",
+        help_text=_("Billing contact for the domain"),
         blank=True,
         null=True,
     )
@@ -104,7 +110,7 @@ class ZoneTemplate(NetBoxModel):
     )
 
     class Meta:
-        verbose_name = "Zone Template"
+        verbose_name = _("Zone Template")
         verbose_name_plural = "Zone Templates"
 
         ordering = ("name",)

--- a/netbox_dns/navigation.py
+++ b/netbox_dns/navigation.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from netbox.plugins import PluginMenuButton, PluginMenuItem, PluginMenu
 from netbox.plugins.utils import get_plugin_config
 
@@ -6,18 +8,18 @@ top_level_menu = get_plugin_config("netbox_dns", "top_level_menu")
 
 view_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:view_list",
-    link_text="Views",
+    link_text=_("Views"),
     permissions=["netbox_dns.view_view"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:view_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_view"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:view_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_view"],
         ),
@@ -26,18 +28,18 @@ view_menu_item = PluginMenuItem(
 
 zone_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:zone_list",
-    link_text="Zones",
+    link_text=_("Zones"),
     permissions=["netbox_dns.view_zone"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:zone_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_zone"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:zone_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_zone"],
         ),
@@ -46,18 +48,18 @@ zone_menu_item = PluginMenuItem(
 
 nameserver_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:nameserver_list",
-    link_text="Nameservers",
+    link_text=_("Nameservers"),
     permissions=["netbox_dns.view_nameserver"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:nameserver_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_nameserver"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:nameserver_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_nameserver"],
         ),
@@ -66,18 +68,18 @@ nameserver_menu_item = PluginMenuItem(
 
 record_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:record_list",
-    link_text="Records",
+    link_text=_("Records"),
     permissions=["netbox_dns.view_record"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:record_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_record"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:record_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_record"],
         ),
@@ -86,24 +88,24 @@ record_menu_item = PluginMenuItem(
 
 managed_record_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:managed_record_list",
-    link_text="Managed Records",
+    link_text=_("Managed Records"),
     permissions=["netbox_dns.view_record"],
 )
 
 zonetemplate_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:zonetemplate_list",
-    link_text="Zone Templates",
+    link_text=_("Zone Templates"),
     permissions=["netbox_dns.view_zonetemplate"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:zonetemplate_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_zonetemplate"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:zonetemplate_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_zonetemplate"],
         ),
@@ -112,18 +114,18 @@ zonetemplate_menu_item = PluginMenuItem(
 
 recordtemplate_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:recordtemplate_list",
-    link_text="Record Templates",
+    link_text=_("Record Templates"),
     permissions=["netbox_dns.view_recordtemplate"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:recordtemplate_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_recordtemplate"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:recordtemplate_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_recordtemplate"],
         ),
@@ -132,18 +134,18 @@ recordtemplate_menu_item = PluginMenuItem(
 
 registrar_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:registrar_list",
-    link_text="Registrars",
+    link_text=_("Registrars"),
     permissions=["netbox_dns.view_registrar"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:registrar_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_registrar"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:registrar_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_registrar"],
         ),
@@ -152,18 +154,18 @@ registrar_menu_item = PluginMenuItem(
 
 contact_menu_item = PluginMenuItem(
     link="plugins:netbox_dns:registrationcontact_list",
-    link_text="Registration Contacts",
+    link_text=_("Registration Contacts"),
     permissions=["netbox_dns.view_registrationcontact"],
     buttons=(
         PluginMenuButton(
             "plugins:netbox_dns:registrationcontact_add",
-            "Add",
+            _("Add"),
             "mdi mdi-plus-thick",
             permissions=["netbox_dns.add_registrationcontact"],
         ),
         PluginMenuButton(
             "plugins:netbox_dns:registrationcontact_import",
-            "Import",
+            _("Import"),
             "mdi mdi-upload",
             permissions=["netbox_dns.add_registrationcontact"],
         ),
@@ -176,7 +178,7 @@ if top_level_menu:
         label=menu_name,
         groups=(
             (
-                "DNS Configuration",
+                _("DNS Configuration"),
                 (
                     view_menu_item,
                     zone_menu_item,
@@ -186,14 +188,14 @@ if top_level_menu:
                 ),
             ),
             (
-                "Templates",
+                _("Templates"),
                 (
                     zonetemplate_menu_item,
                     recordtemplate_menu_item,
                 ),
             ),
             (
-                "Domain Registration",
+                _("Domain Registration"),
                 (
                     registrar_menu_item,
                     contact_menu_item,

--- a/netbox_dns/tables/ipam_dnssync.py
+++ b/netbox_dns/tables/ipam_dnssync.py
@@ -1,10 +1,11 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from ipam.tables import PrefixTable
 from utilities.tables import register_table_column
 
 views = tables.ManyToManyColumn(
-    verbose_name="DNS Views",
+    verbose_name=_("DNS Views"),
     linkify_item=True,
 )
 

--- a/netbox_dns/tables/nameserver.py
+++ b/netbox_dns/tables/nameserver.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn
 from tenancy.tables import TenancyColumnsMixin
@@ -11,6 +12,7 @@ __all__ = ("NameServerTable",)
 
 class NameServerTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     tags = TagColumn(

--- a/netbox_dns/tables/record.py
+++ b/netbox_dns/tables/record.py
@@ -1,5 +1,7 @@
 import django_tables2 as tables
 from django.utils.html import format_html
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 
 from netbox.tables import (
@@ -23,33 +25,39 @@ __all__ = (
 
 class RecordBaseTable(TenancyColumnsMixin, NetBoxTable):
     zone = tables.Column(
+        verbose_name=_("Zone"),
         linkify=True,
     )
     view = tables.Column(
+        verbose_name=_p("DNS", "View"),
         accessor="zone__view",
         linkify=True,
     )
-    type = tables.Column()
+    type = tables.Column(
+        verbose_name=_("Type"),
+    )
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     fqdn = tables.Column(
-        verbose_name="FQDN",
+        verbose_name=_("FQDN"),
         linkify=True,
     )
     value = tables.TemplateColumn(
+        verbose_name=_("Value"),
         template_code="{{ value|truncatechars:64 }}",
     )
     unicode_value = tables.TemplateColumn(
-        verbose_name="Unicode Value",
+        verbose_name=_("Unicode Value"),
         template_code="{{ value|truncatechars:64 }}",
         accessor="value",
     )
     ttl = tables.Column(
-        verbose_name="TTL",
+        verbose_name=_("TTL"),
     )
     active = tables.BooleanColumn(
-        verbose_name="Active",
+        verbose_name=_("Active"),
     )
 
     def render_name(self, value, record):
@@ -60,15 +68,17 @@ class RecordBaseTable(TenancyColumnsMixin, NetBoxTable):
 
 
 class RecordTable(RecordBaseTable):
-    status = ChoiceFieldColumn()
+    status = ChoiceFieldColumn(
+        verbose_name=_("Status"),
+    )
     disable_ptr = tables.BooleanColumn(
-        verbose_name="Disable PTR",
+        verbose_name=_("Disable PTR"),
     )
     tags = TagColumn(
         url_name="plugins:netbox_dns:record_list",
     )
     ptr_record = tables.Column(
-        verbose_name="PTR Record",
+        verbose_name=_("PTR Record"),
         linkify=True,
     )
 
@@ -91,15 +101,15 @@ class RecordTable(RecordBaseTable):
 
 class ManagedRecordTable(RecordBaseTable):
     address_record = tables.Column(
-        verbose_name="Address Record",
+        verbose_name=_("Address Record"),
         linkify=True,
     )
     ipam_ip_address = tables.Column(
-        verbose_name="IPAM IP Address",
+        verbose_name=_("IPAM IP Address"),
         linkify=True,
     )
     related_ip_address = tables.Column(
-        verbose_name="Related IP Address",
+        verbose_name=_("Related IP Address"),
         empty_values=(),
         orderable=False,
     )

--- a/netbox_dns/tables/record_template.py
+++ b/netbox_dns/tables/record_template.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn, ActionsColumn
 from tenancy.tables import TenancyColumnsMixin
@@ -15,23 +16,29 @@ __all__ = (
 
 class RecordTemplateTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
-    record_name = tables.Column()
-    type = tables.Column()
+    record_name = tables.Column(
+        verbose_name=_("Record Name"),
+    )
+    type = tables.Column(
+        verbose_name=_("Type"),
+    )
     value = tables.TemplateColumn(
+        verbose_name=_("Value"),
         template_code="{{ value|truncatechars:64 }}",
     )
     unicode_value = tables.TemplateColumn(
-        verbose_name="Unicode Value",
+        verbose_name=_("Unicode Value"),
         template_code="{{ value|truncatechars:64 }}",
         accessor="value",
     )
     ttl = tables.Column(
-        verbose_name="TTL",
+        verbose_name=_("TTL"),
     )
     disable_ptr = tables.BooleanColumn(
-        verbose_name="Disable PTR",
+        verbose_name=_("Disable PTR"),
     )
     tags = TagColumn(
         url_name="plugins:netbox_dns:recordtemplate_list",

--- a/netbox_dns/tables/registrar.py
+++ b/netbox_dns/tables/registrar.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn
 
@@ -10,6 +11,7 @@ __all__ = ("RegistrarTable",)
 
 class RegistrarTable(NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     tags = TagColumn(

--- a/netbox_dns/tables/registration_contact.py
+++ b/netbox_dns/tables/registration_contact.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn
 
@@ -10,6 +11,7 @@ __all__ = ("RegistrationContactTable",)
 
 class RegistrationContactTable(NetBoxTable):
     contact_id = tables.Column(
+        verbose_name=_("Contact ID"),
         linkify=True,
     )
     tags = TagColumn(

--- a/netbox_dns/tables/view.py
+++ b/netbox_dns/tables/view.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn, ActionsColumn
 from tenancy.tables import TenancyColumnsMixin
@@ -14,10 +15,11 @@ __all__ = (
 
 class ViewTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     default_view = tables.BooleanColumn(
-        verbose_name="Default View",
+        verbose_name=_("Default View"),
     )
     tags = TagColumn(url_name="plugins:netbox_dns:view_list")
 

--- a/netbox_dns/tables/zone.py
+++ b/netbox_dns/tables/zone.py
@@ -1,4 +1,6 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy as _p
 
 from netbox.tables import (
     ChoiceFieldColumn,
@@ -15,15 +17,20 @@ __all__ = ("ZoneTable",)
 
 class ZoneTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     view = tables.Column(
+        verbose_name=_p("DNS", "View"),
         linkify=True,
     )
     soa_mname = tables.Column(
+        verbose_name=_("SOA MName"),
         linkify=True,
     )
-    status = ChoiceFieldColumn()
+    status = ChoiceFieldColumn(
+        verbose_name=_("Status"),
+    )
     tags = TagColumn(
         url_name="plugins:netbox_dns:zone_list",
     )
@@ -31,24 +38,30 @@ class ZoneTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name="Default TTL",
     )
     rfc2317_prefix = tables.Column(
-        verbose_name="RFC2317 Prefix",
+        verbose_name=_("RFC2317 Prefix"),
     )
     rfc2317_parent_zone = tables.Column(
+        verbose_name=_("RFC2317 Parent Zone"),
         linkify=True,
     )
     registrar = tables.Column(
+        verbose_name=_("Registrar"),
         linkify=True,
     )
     registrant = tables.Column(
+        verbose_name=_("Registrant"),
         linkify=True,
     )
     admin_c = tables.Column(
+        verbose_name=_("Administrative Contact"),
         linkify=True,
     )
     tech_c = tables.Column(
+        verbose_name=_("Technical Contact"),
         linkify=True,
     )
     billing_c = tables.Column(
+        verbose_name=_("Billing Contact"),
         linkify=True,
     )
 

--- a/netbox_dns/tables/zone_template.py
+++ b/netbox_dns/tables/zone_template.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, TagColumn, ActionsColumn
 from tenancy.tables import TenancyColumnsMixin
@@ -14,24 +15,30 @@ __all__ = (
 
 class ZoneTemplateTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
+        verbose_name=_("Name"),
         linkify=True,
     )
     tags = TagColumn(
         url_name="plugins:netbox_dns:zonetemplate_list",
     )
     registrar = tables.Column(
+        verbose_name=_("Registrar"),
         linkify=True,
     )
     registrant = tables.Column(
+        verbose_name=_("Registrant"),
         linkify=True,
     )
     admin_c = tables.Column(
+        verbose_name=_("Administrative Contact"),
         linkify=True,
     )
     tech_c = tables.Column(
+        verbose_name=_("Technical Contact"),
         linkify=True,
     )
     billing_c = tables.Column(
+        verbose_name=_("Billing Contact"),
         linkify=True,
     )
 

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -1,29 +1,30 @@
 {% extends 'generic/object.html' %}
+{% load i18n %}
 
 {% block content %}
     <div class="row">
         <div class="col col-md-6">
             <div class="card">
-                <h5 class="card-header">Name Server</h5>
+                <h5 class="card-header">{% trans "Nameserver" %}</h5>
                 <table class="table table-hover attr-table">
                     <tr>
-                        <th scope="row">Name</th>
+                        <th scope="row">{% trans "Name" %}</th>
                         <td>{{ object.name }}</td>
                     </tr>
                     {% if unicode_name %}
                     <tr>
-                        <th scope="row">IDN</th>
+                        <th scope="row">{% trans "IDN" %}</th>
                         <td>{{ unicode_name }}</td>
                     </tr>
                     {% endif %}
                     {% if object.description %}
                     <tr>
-                        <th scope="row">Description</th>
+                        <th scope="row">{% trans "Description" %}</th>
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
                     <tr>
-                        <th scope="row">Tenant</th>
+                        <th scope="row">{% trans "Tenant" %}</th>
                         <td>
                             {% if object.tenant.group %}
                                 {{ object.tenant.group|linkify }} /

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -3,6 +3,7 @@
 {% load plugins %}
 {% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% block control-buttons %}
 {% if object.managed %}
@@ -14,7 +15,7 @@
 {% block breadcrumbs %}
 {% if object.managed %}
 <li class="breadcrumb-item">
-    <a href="{% url 'plugins:netbox_dns:managed_record_list' %}">{{ 'Managed Records' }}</a>
+    <a href="{% url 'plugins:netbox_dns:managed_record_list' %}">{% trans "Managed Records" %}</a>
 </li>
 {% else %}
 {{ block.super }}
@@ -36,20 +37,20 @@
     <div class="col col-md-8">
     {% endif %}
         <div class="card">
-            <h5 class="card-header">Record</h5>
+            <h5 class="card-header">{% trans "Record" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Name</th>
+                    <th scope="row">{% trans "Name" %}</th>
                     <td style="word-break:break-all;">{{ object.name }}</td>
                 </tr>
                 {% if unicode_name %}
                 <tr>
-                    <th scope="row">IDN</th>
+                    <th scope="row">{% trans "IDN" %}</th>
                     <td style="word-break:break-all;">{{ unicode_name }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Zone</th>
+                    <th scope="row">{% trans "Zone" %}</th>
                     {% if object.managed %}
                     <td><a href="{% url 'plugins:netbox_dns:zone_managed_records' pk=object.zone.pk %}">{{ object.zone }}</a></td>
                     {% else %}
@@ -58,7 +59,7 @@
                 </tr>
                 {% if not object.managed or object.tenant %}
                 <tr>
-                    <th scope="row">Tenant</th>
+                    <th scope="row">{% trans "Tenant" %}</th>
                     <td>
                         {% if object.tenant.group %}
                             {{ object.tenant.group|linkify }} /
@@ -68,50 +69,50 @@
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Type</th>
+                    <th scope="row">{% trans "Type" %}</th>
                     <td>{{ object.type }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Value</th>
+                    <th scope="row">{% trans "Value" %}</th>
                     <td style="word-break:break-all;">{{ object.value }}</td>
                 </tr>
                 {% if unicode_value %}
                 <tr>
-                    <th scope="row">Unicode Value</th>
+                    <th scope="row">{% trans "Unicode Value" %}</th>
                     <td style="word-break:break-all;">{{ unicode_value }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">TTL</th>
+                    <th scope="row">{% trans "TTL" %}</th>
                     <td>{{ object.ttl|placeholder }}</td>
                 </tr>
                 {% if object.type == 'A' or object.type == 'AAAA' %}
                 <tr>
-                    <th scope="row">Disable PTR</th>
+                    <th scope="row">{% trans "Disable PTR" %}</th>
                     <td>{% checkmark object.disable_ptr %}</td>
                 </tr>
                 {% endif %}
                 {% if object.ptr_record %}
                 <tr>
-                    <th scope="row">PTR Record</th>
+                    <th scope="row">{% trans "PTR Record" %}</th>
                     <td>{{ object.ptr_record|linkify }}</td>
                 </tr>
                 {% endif %}
                 {% if object.address_record %}
                 <tr>
-                    <th scope="row">Address Record</th>
+                    <th scope="row">{% trans "Address Record" %}</th>
                     <td>{{ object.address_record|linkify }}</td>
                 </tr>
                 {% if object.address_record.ipam_ip_address %}
                 <tr>
-                    <th scope="row">IPAM IP Address</th>
+                    <th scope="row">{% trans "IPAM IP Address" %}</th>
                     <td>{{ object.address_record.ipam_ip_address|linkify }}</td>
                 </tr>
                 {% endif %}
                 {% endif %}
                 {% if object.ipam_ip_address %}
                 <tr>
-                    <th scope="row">IPAM IP Address</th>
+                    <th scope="row">{% trans "IPAM IP Address" %}</th>
                     <td>{{ object.ipam_ip_address|linkify }}</td>
                 </tr>
                 {% endif %}
@@ -121,16 +122,34 @@
                 </tr>
                 {% if object.description %}
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
             </table>
         </div>
-        {% if cname_target_table and cname_target_table.rows|length > 0 %}
-        {% include 'inc/panel_table.html' with table=cname_target_table heading='CNAME Targets' %}
-        {% elif cname_table and cname_table.rows|length > 0 %}
-        {% include 'inc/panel_table.html' with table=cname_table heading='CNAMEs' %}
+        {% if cname_target_table %}
+            <div class="card">
+                {% if cname_target_table.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "CNAME Target" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "CNAME Targets" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table cname_target_table 'inc/table.html' %}
+                </div>
+            </div>
+        {% elif cname_table %}
+            <div class="card">
+                {% if cname_table.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "CNAME" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "CNAMEs" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table cname_table 'inc/table.html' %}
+                </div>
+            </div>
         {% endif %}
         {% if not object.managed %}
         {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_dns/templates/netbox_dns/record/managed.html
+++ b/netbox_dns/templates/netbox_dns/record/managed.html
@@ -1,3 +1,4 @@
 {% extends 'generic/object_list.html' %}
+{% load i18n %}
 
-{% block title %}Managed Records{% endblock %}
+{% block title %}{% trans "Managed Records" %}{% endblock %}

--- a/netbox_dns/templates/netbox_dns/record/related.html
+++ b/netbox_dns/templates/netbox_dns/record/related.html
@@ -1,18 +1,30 @@
+{% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% if perms.netbox_dns.view_record %}
-{% if related_address_records %}
-{% if related_address_records.rows|length == 1 %}
-{% include 'inc/panel_table.html' with table=related_address_records heading='Related DNS Address Record' %}
-{% else %}
-{% include 'inc/panel_table.html' with table=related_address_records heading='Related DNS Address Records' %}
-{% endif %}
-{% endif %}
-{% if related_pointer_records %}
-{% if related_pointer_records.rows|length == 1 %}
-{% include 'inc/panel_table.html' with table=related_pointer_records heading='Related DNS Pointer Record' %}
-{% else %}
-{% include 'inc/panel_table.html' with table=related_pointer_records heading='Related DNS Pointer Records' %}
-{% endif %}
-{% endif %}
+    {% if related_address_records %}
+        <div class="card">
+            {% if related_address_records.rows|length == 1 %}
+                <h2 class="card-header">{% trans "Related DNS Address Record" %}</h2>
+            {% else %}
+                <h2 class="card-header">{% trans "Related DNS Address Records" %}</h2>
+            {% endif %}
+            <div class="table-responsive">
+                {% render_table related_address_records 'inc/table.html' %}
+            </div>
+        </div>
+    {% endif %}
+    {% if related_pointer_records %}
+        <div class="card">
+            {% if related_pointer_records.rows|length == 1 %}
+                <h2 class="card-header">{% trans "Related DNS Pointer Record" %}</h2>
+            {% else %}
+                <h2 class="card-header">{% trans "Related DNS Pointer Records" %}</h2>
+            {% endif %}
+            <div class="table-responsive">
+                {% render_table related_pointer_records 'inc/table.html' %}
+            </div>
+        </div>
+    {% endif %}
 {% endif %}

--- a/netbox_dns/templates/netbox_dns/recordtemplate.html
+++ b/netbox_dns/templates/netbox_dns/recordtemplate.html
@@ -3,30 +3,31 @@
 {% load plugins %}
 {% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% block content %}
 <div class="row">
     <div class="col col-md-8">
         <div class="card">
-            <h5 class="card-header">Record Template</h5>
+            <h5 class="card-header">{% trans "Record Template" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Template Name</th>
+                    <th scope="row">{% trans "Template Name" %}</th>
                     <td style="word-break:break-all;">{{ object.name }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Name</th>
+                    <th scope="row">{% trans "Name" %}</th>
                     <td style="word-break:break-all;">{{ object.record_name }}</td>
                 </tr>
                 {% if unicode_name %}
                 <tr>
-                    <th scope="row">IDN</th>
+                    <th scope="row">{% trans "IDN" %}</th>
                     <td style="word-break:break-all;">{{ unicode_name }}</td>
                 </tr>
                 {% endif %}
                 {% if object.tenant %}
                 <tr>
-                    <th scope="row">Tenant</th>
+                    <th scope="row">{% trans "Tenant" %}</th>
                     <td>
                         {% if object.tenant.group %}
                             {{ object.tenant.group|linkify }} /
@@ -36,36 +37,36 @@
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Type</th>
+                    <th scope="row">{% trans "Type" %}</th>
                     <td>{{ object.type }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Value</th>
+                    <th scope="row">{% trans "Value" %}</th>
                     <td style="word-break:break-all;">{{ object.value }}</td>
                 </tr>
                 {% if unicode_value %}
                 <tr>
-                    <th scope="row">Unicode Value</th>
+                    <th scope="row">{% trans "Unicode Value" %}/th>
                     <td style="word-break:break-all;">{{ unicode_value }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">TTL</th>
+                    <th scope="row">{% trans "TTL" %}</th>
                     <td>{{ object.ttl|placeholder }}</td>
                 </tr>
                 {% if object.type == 'A' or object.type == 'AAAA' %}
                 <tr>
-                    <th scope="row">Disable PTR</th>
+                    <th scope="row">{% trans "Disable PTR" %}</th>
                     <td>{% checkmark object.disable_ptr %}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Status</th>
+                    <th scope="row">{% trans "Status" %}</th>
                     <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                 </tr>
                 {% if object.description %}
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
@@ -76,9 +77,20 @@
     <div class="col col-md-4">
         {% include 'inc/panels/tags.html' %}
     </div>
-    <div class="col col-md-12">
-      {% include 'inc/panel_table.html' with table=zone_template_table heading="Zone Templates" %}
-    </div>
+    {% if zone_template_table %}
+        <div class="col col-md-12">
+            <div class="card">
+                {% if zone_template_table.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "Zone Template" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "Zone Templates" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table zone_template_table 'inc/table.html' %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/registrar.html
+++ b/netbox_dns/templates/netbox_dns/registrar.html
@@ -1,48 +1,49 @@
 {% extends 'generic/object.html' %}
+{% load i18n %}
 
 {% block content %}
     <div class="row">
         <div class="col col-md-6">
             <div class="card">
-                <h5 class="card-header">Registrar</h5>
+                <h5 class="card-header">{% trans "Registrar" %}</h5>
                 <table class="table table-hover attr-table">
                     <tr>
-                        <th scope="row">Name</th>
+                        <th scope="row">{% trans "Name" %}</th>
                         <td>{{ object.name }}</td>
                     </tr>
                     {% if object.description %}
                     <tr>
-                        <th scope="row">Description</th>
+                        <th scope="row">{% trans "Description" %}</th>
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
                     <tr>
-                        <th scope="row">IANA ID</th>
+                        <th scope="row">{% trans "IANA ID" %}</th>
                         <td>{{ object.iana_id }}</td>
                     </tr>
                 </table>
             </div>
             <div class="card">
-                <h5 class="card-header">Contact Details</h5>
+                <h5 class="card-header">{% trans "Contact Details" %}</h5>
                 <table class="table table-hover attr-table">
                     <tr>
-                        <th scope="row">Address</th>
+                        <th scope="row">{% trans "Address" %}</th>
                         <td>{{ object.address }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Referral URL</th>
+                        <th scope="row">{% trans "Referral URL" %}</th>
                         <td><a href="{{ object.referral_url }}">{{ object.referral_url }}</a></td>
                     </tr>
                     <tr>
-                        <th scope="row">WHOIS Server</th>
+                        <th scope="row">{% trans "WHOIS Server" %}</th>
                         <td>{{ object.whois_server }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Abuse Email</th>
+                        <th scope="row">{% trans "Abuse Email" %}</th>
                         <td>{{ object.abuse_email }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Abuse Phone</th>
+                        <th scope="row">{% trans "Abuse Phone" %}</th>
                         <td>{{ object.abuse_phone }}</td>
                     </tr>
                 </table>

--- a/netbox_dns/templates/netbox_dns/registrationcontact.html
+++ b/netbox_dns/templates/netbox_dns/registrationcontact.html
@@ -1,67 +1,68 @@
 {% extends 'generic/object.html' %}
+{% load i18n %}
 
 {% block content %}
     <div class="row">
         <div class="col col-md-6">
             <div class="card">
-                <h5 class="card-header">Registration Contact</h5>
+                <h5 class="card-header">{% trans "Registration Contact" %}</h5>
                 <table class="table table-hover attr-table">
                     <tr>
-                        <th scope="row">Name</th>
+                        <th scope="row">{% trans "Name" %}</th>
                         <td>{{ object.name }}</td>
                     </tr>
                      {% if object.description %}
                     <tr>
-                        <th scope="row">Description</th>
+                        <th scope="row">{% trans "Description" %}</th>
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
                    <tr>
-                        <th scope="row">Contact ID</th>
+                        <th scope="row">{% trans "Contact ID" %}</th>
                         <td>{{ object.contact_id }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Organization</th>
+                        <th scope="row">{% trans "Organization" %}</th>
                         <td>{{ object.organization }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Street</th>
+                        <th scope="row">{% trans "Street" %}</th>
                         <td>{{ object.street }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">City</th>
+                        <th scope="row">{% trans "City" %}</th>
                         <td>{{ object.city }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">State/Province</th>
+                        <th scope="row">{% trans "State/Province" %}</th>
                         <td>{{ object.state_province }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Postal Code</th>
+                        <th scope="row">{% trans "Postal Code" %}</th>
                         <td>{{ object.postal_code }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Country</th>
+                        <th scope="row">{% trans "Country" %}</th>
                         <td>{{ object.country }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Phone</th>
+                        <th scope="row">{% trans "Phone" %}</th>
                         <td>{{ object.phone }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Phone Extension</th>
+                        <th scope="row">{% trans "Phone Extension" %}</th>
                         <td>{{ object.phone_ext }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Fax</th>
+                        <th scope="row">{% trans "Fax" %}</th>
                         <td>{{ object.fax }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Fax Extension</th>
+                        <th scope="row">{% trans "Fax Extension" %}</th>
                         <td>{{ object.fax_ext }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Email</th>
+                        <th scope="row">{% trans "Email" %}</th>
                         <td>{{ object.email }}</td>
                     </tr>
                 </table>

--- a/netbox_dns/templates/netbox_dns/view.html
+++ b/netbox_dns/templates/netbox_dns/view.html
@@ -1,27 +1,28 @@
 {% extends 'generic/object.html' %}
+{% load i18n %}
 
 {% block content %}
     <div class="row">
         <div class="col col-md-6">
             <div class="card">
-                <h5 class="card-header">View</h5>
+                <h5 class="card-header">{% trans "View" context "DNS" %}</h5>
                 <table class="table table-hover attr-table">
                     <tr>
-                        <th scope="row">Name</th>
+                        <th scope="row">{% trans "Name" %}</th>
                         <td>{{ object.name }}</td>
                     </tr>
                     <tr>
-                        <th scope="row">Default View</th>
+                        <th scope="row">{% trans "Default View" %}</th>
                         <td>{% checkmark object.default_view %}</td>
                     </tr>
                     {% if object.description %}
                     <tr>
-                        <th scope="row">Description</th>
+                        <th scope="row">{% trans "Description" %}</th>
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
                     <tr>
-                        <th scope="row">Tenant</th>
+                        <th scope="row">{% trans "Tenant" %}</th>
                         <td>
                             {% if object.tenant.group %}
                                 {{ object.tenant.group|linkify }} /
@@ -37,9 +38,7 @@
             {% include 'inc/panels/tags.html' %}
             {% if not settings.PLUGINS_CONFIG.netbox_dns.dnssync_disabled %}
             <div class="card">
-                <h5 class="card-header">
-                    IPAM Prefixes
-                </h5>
+                <h5 class="card-header">{% trans "IPAM Prefixes" %}</h5>
                 <div class="card-body">
                     <table class="table table-hover attr-table">
                         {% if object.prefixes.exists %}
@@ -53,25 +52,23 @@
                                 {{ prefix.vrf|linkify }}
                             </td>
                             {% else %}
-                            <td>Global</td>
+                            <td>{% trans "Global" %}</td>
                             {% endif %}
                         </tr>
                         {% endfor %}
                         {% else %}
-                            <span class="text-muted">No prefixes assigned</span>
+                            <span class="text-muted">{% trans "No prefixes assigned" %}</span>
                         {% endif %}
                     </table>
                 </div>
             </div>
             <div class="card">
-                <h5 class="card-header">
-                    IP Address Filters
-                </h5>
+                <h5 class="card-header">{% trans "IP Address Filters" %}</h5>
                 <div class="card-body">
                     {% if object.ip_address_filter %}
                         <pre>{{ object.ip_address_filter|json }}</pre>
                     {% else %}
-                        <span class="text-muted">No filters defined</span>
+                        <span class="text-muted">{% trans "No filters defined" %}</span>
                     {% endif %}
                 </div>
             </div>

--- a/netbox_dns/templates/netbox_dns/view/button.html
+++ b/netbox_dns/templates/netbox_dns/view/button.html
@@ -1,9 +1,10 @@
 {% load perms %}
+{% load i18n %}
 
 {% if perms.netbox_dns.change_view %}
 <a href="{{ url }}?return_url={{ object.get_absolute_url }}">
     <button type="submit" class="btn btn-primary" name="assign-view">
-        <i class="mdi mdi-eye-outline" aria-hidden="true"></i> DNS Views
+        <i class="mdi mdi-eye-outline" aria-hidden="true"></i> {% trans "DNS Views" %}
     </button>
 </a>
 {% endif %}

--- a/netbox_dns/templates/netbox_dns/view/prefix.html
+++ b/netbox_dns/templates/netbox_dns/view/prefix.html
@@ -1,7 +1,10 @@
 {% extends 'generic/_base.html' %}
+{% load i18n %}
 
 {% block title %}
-Configure DNS views for {{ object|meta:"verbose_name" }} {{ object }} {% if object.vrf %}[{{ object.vrf }}]{% endif %}
+{% blocktrans trimmed with type=object|meta:"verbose_name" name=object vrf=object.vrf|default:"" %}
+Configure DNS views for {{ type }} {{ name }} {{ vrf }}
+{% endblocktrans %}
 {% endblock title %}
 
 {% block content %}
@@ -14,7 +17,7 @@ Configure DNS views for {{ object|meta:"verbose_name" }} {{ object }} {% if obje
     {% if inherited_from %}
         <div class="card">
             <table class="table table-hover attr-table">
-                <th>Views inherited from prefix {{ inherited_from }} {% if inherited_from.vrf %}[{{ inherited_from.vrf }}] {% endif %}</th>
+                <th>{% trans "Views inherited from prefix" %} {{ inherited_from }} {% if inherited_from.vrf %}[{{ inherited_from.vrf }}] {% endif %}</th>
                 {% for view in inherited_views %}
                     <tr><td>{{ view|linkify }}</td><td>{{ view.description }}</td></tr>
                 {% endfor %}
@@ -28,8 +31,8 @@ Configure DNS views for {{ object|meta:"verbose_name" }} {{ object }} {% if obje
 
     <div class="text-end my-3">
     {% block buttons %}
-        <a href="{{ return_url }}" class="btn btn-outline-secondary">Cancel</a>
-        <button type="submit" name="_update" class="btn btn-primary">Save</button>
+        <a href="{{ return_url }}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
+        <button type="submit" name="_update" class="btn btn-primary">{% trans "Save" %}</button>
     {% endblock buttons %}
     </div>
     </form>

--- a/netbox_dns/templates/netbox_dns/view/related.html
+++ b/netbox_dns/templates/netbox_dns/view/related.html
@@ -1,17 +1,33 @@
+{% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% if perms.netbox_dns.view_view %}
     {% if assigned_views %}
-        {% if assigned_views.rows|length == 1 %}
-            {% include 'inc/panel_table.html' with table=assigned_views heading='Assigned DNS View' %}
-        {% else %}
-            {% include 'inc/panel_table.html' with table=assigned_views heading='Assigned DNS Views' %}
-        {% endif %}
+        <div class="col col-md-12">
+            <div class="card">
+                {% if assigned_views.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "Assigned DNS View" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "Assigned DNS Views" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table assigned_views 'inc/table.html' %}
+                </div>
+            </div>
+        </div>
     {% elif inherited_views %}
-        {% if inherited_views.rows|length == 1 %}
-            {% include 'inc/panel_table.html' with table=inherited_views heading='Inherited DNS View' %}
-        {% else %}
-            {% include 'inc/panel_table.html' with table=inherited_views heading='Inherited DNS Views' %}
-        {% endif %}
+        <div class="col col-md-12">
+            <div class="card">
+                {% if inherited_views.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "Inherited DNS View" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "Inherited DNS Views" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table inherited_views 'inc/table.html' %}
+                </div>
+            </div>
+        </div>
     {% endif %}
 {% endif %}

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -1,43 +1,41 @@
 {% extends 'netbox_dns/zone/base.html' %}
 {% load helpers %}
-{% load render_table from django_tables2 %}
+{% load i18n %}
 
 {% block content %}
 <div class="row">
     <div class="col col-md-6">
         <div class="card">
-            <h5 class="card-header">
-                Zone
-            </h5>
+            <h5 class="card-header">{% trans "Zone" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Name</th>
+                    <th scope="row">{% trans "Name" %}</th>
                     <td>{{ object.name }}</td>
                 </tr>
                 {% if unicode_name %}
                     <tr>
-                        <th scope="row">IDN</th>
+                        <th scope="row">{% trans "IDN" %}</th>
                         <td>{{ unicode_name }}</td>
                     </tr>
                 {% endif %}
                 {% if parent_zone %}
                     <tr>
-                        <th scope="row">Parent Zone</th>
+                        <th scope="row">{% trans "Parent Zone" %}</th>
                         <td>{{ parent_zone|linkify }}</td>
                     </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">View</th>
+                    <th scope="row">{% trans "View" context "DNS" %}</th>
                     <td>{{ object.view|linkify }}</td>
                 </tr>
                 {% if object.description %}
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Tenant</th>
+                    <th scope="row">{% trans "Tenant" %}</th>
                     <td>
                         {% if object.tenant.group %}
                             {{ object.tenant.group|linkify }} /
@@ -46,11 +44,11 @@
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Status</th>
+                    <th scope="row">{% trans "Status" %}</th>
                     <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Nameservers</th>
+                    <th scope="row">{% trans "Nameservers" %}</th>
                     <td>
                         <table>
                             {% for nameserver in object.nameservers.all %}
@@ -60,7 +58,7 @@
                     </td>
                 {% if nameserver_warnings %}
                 <tr>
-                    <th class="text-warning" scope="row">Warnings</th>
+                    <th class="text-warning" scope="row">{% trans "Warnings" %}</th>
                     <td>
                         <table>
                             {% for warning in nameserver_warnings %}
@@ -74,7 +72,7 @@
                 {% endif %}
                 {% if nameserver_errors %}
                 <tr>
-                    <th class="text-danger" scope="row">Errors</th>
+                    <th class="text-danger" scope="row">{% trans "Errors" %}</th>
                     <td>
                         <table>
                             {% for error in nameserver_errors %}
@@ -88,11 +86,11 @@
                 {% endif %}
                 </tr>
                 <tr>
-                    <th scope="row">Default TTL</th>
+                    <th scope="row">{% trans "Default TTL" %}</th>
                     <td>{{ object.default_ttl }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td>{{ object.description }}</td>
                 </tr>
             </table>
@@ -103,64 +101,64 @@
     </div>
     <div class="col col-md-6">
         <div class="card">
-            <h5 class="card-header">Zone SOA</h5>
+            <h5 class="card-header">{% trans "Zone SOA" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">TTL</th>
+                    <th scope="row">{% trans "TTL" %}</th>
                     <td>{{ object.soa_ttl }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">MName</th>
+                    <th scope="row">{% trans "MName" %}</th>
                     <td>{{ object.soa_mname|linkify }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">RName</th>
+                    <th scope="row">{% trans "RName" %}</th>
                     <td>{{ object.soa_rname }}</td>
                 </tr>
                 {% if object.soa_serial_auto %}
                 <tr>
-                    <th scope="row">Serial (auto-generated)</th>
+                    <th scope="row">{% trans "Serial (auto-generated)" %}</th>
                     <td>{{ object.soa_serial }}</td>
                 </tr>
                 {% else %}
                 <tr>
-                    <th scope="row">Serial</th>
+                    <th scope="row">{% trans "Serial" context "SOA" %}</th>
                     <td>{{ object.soa_serial }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Refresh</th>
+                    <th scope="row">{% trans "Refresh" %}</th>
                     <td>{{ object.soa_refresh }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Retry</th>
+                    <th scope="row">{% trans "Retry" %}</th>
                     <td>{{ object.soa_retry }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Expire</th>
+                    <th scope="row">{% trans "Expire" %}</th>
                     <td>{{ object.soa_expire }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Minimum TTL</th>
+                    <th scope="row">{% trans "Minimum TTL" %}</th>
                     <td>{{ object.soa_minimum }}</td>
                 </tr>
             </table>
         </div>
         {% if object.rfc2317_prefix %}
         <div class="card">
-            <h5 class="card-header">RFC2317</h5>
+            <h5 class="card-header">{% trans "RFC2317" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Prefix</th>
+                    <th scope="row">{% trans "Prefix" %}</th>
                     <td>{{ object.rfc2317_prefix }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Parent Managed</th>
+                    <th scope="row">{% trans "Parent Managed" %}</th>
                     <td>{% checkmark object.rfc2317_parent_managed %}</td>
                 </tr>
                 {% if object.rfc2317_parent_managed %}
                 <tr>
-                    <th scope="row">Parent Zone</th>
+                    <th scope="row">{% trans "Parent Zone" %}</th>
                     <td>{{ object.rfc2317_parent_zone|linkify }}</td>
                 </tr>
                 {% endif %}

--- a/netbox_dns/templates/netbox_dns/zone/base.html
+++ b/netbox_dns/templates/netbox_dns/zone/base.html
@@ -3,12 +3,13 @@
 {% load helpers %}
 {% load plugins %}
 {% load perms %}
+{% load i18n %}
 
 {% block extra_controls %}
 {% if perms.netbox_dns.add_record %}
 <a href="{% url 'plugins:netbox_dns:record_add' %}?zone={{ object.pk }}&return_url={{ object.get_absolute_url }}">
     <button type="submit" class="btn btn-primary" name="add-record">
-        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>Add Record
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>{% trans "Add Record" %}
     </button>
 </a>
 {% endif %}

--- a/netbox_dns/templates/netbox_dns/zone/child.html
+++ b/netbox_dns/templates/netbox_dns/zone/child.html
@@ -2,6 +2,7 @@
 {% load helpers %}
 {% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% block content %}
     {% include 'inc/table_controls_htmx.html' with table_modal="ZoneTable_config" %}
@@ -23,12 +24,12 @@
                          {% block bulk_buttons %}{% endblock %}
                          {% if bulk_edit_url and perms.netbox_dns.change_zone %}
                              <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning">
-                                 <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit Selected
+                                 <i class="mdi mdi-pencil" aria-hidden="true"></i> {% trans "Edit Selected" %}
                              </button>
                          {% endif %}
                          {% if bulk_delete_url and perms.netbox_dns.delete_zone %}
                              <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger">
-                                 <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> Delete Selected
+                                 <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {% trans "Delete Selected" %}
                              </button>
                          {% endif %}
                      </div>

--- a/netbox_dns/templates/netbox_dns/zone/record.html
+++ b/netbox_dns/templates/netbox_dns/zone/record.html
@@ -2,6 +2,7 @@
 {% load helpers %}
 {% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% block content %}
     {% include 'inc/table_controls_htmx.html' with table_modal="RecordTable_config" %}
@@ -23,12 +24,12 @@
                            {% block bulk_buttons %}{% endblock %}
                            {% if bulk_edit_url and perms.netbox_dns.change_record %}
                                <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning">
-                                   <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit Selected
+                                   <i class="mdi mdi-pencil" aria-hidden="true"></i> {% trans "Edit Selected" %}
                                </button>
                            {% endif %}
                            {% if bulk_delete_url and perms.netbox_dns.delete_record %}
                                <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger">
-                                   <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> Delete Selected
+                                   <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {% trans "Delete Selected" %}
                                </button>
                            {% endif %}
                        </div>

--- a/netbox_dns/templates/netbox_dns/zone/registration.html
+++ b/netbox_dns/templates/netbox_dns/zone/registration.html
@@ -1,32 +1,33 @@
 {% extends 'netbox_dns/zone/base.html' %}
 {% load helpers %}
+{% load i18n %}
 
 {% block content %}
 <div class="card">
-    <h5 class="card-header">Domain Registration</h5>
+    <h5 class="card-header">{% trans "Domain Registration" %}</h5>
     <table class="table table-hover attr-table">
         <tr>
-            <th scope="row">Registrar</th>
+            <th scope="row">{% trans "Registrar" %}</th>
             <td>{{ object.registrar|linkify|placeholder }}</td>
         </tr>
         <tr>
-            <th scope="row">Registry Domain ID</th>
+            <th scope="row">{% trans "Registry Domain ID" %}</th>
             <td>{{ object.registry_domain_id|placeholder }}</td>
         </tr>
         <tr>
-            <th scope="row">Registrant</th>
+            <th scope="row">{% trans "Registrant" %}</th>
             <td>{{ object.registrant|linkify|placeholder }}</td>
         </tr>
         <tr>
-            <th scope="row">Administrative Contact</th>
+            <th scope="row">{% trans "Administrative Contact" %}</th>
             <td>{{ object.admin_c|linkify|placeholder }}</td>
         </tr>
         <tr>
-            <th scope="row">Technical Contact</th>
+            <th scope="row">{% trans "Technical Contact" %}</th>
             <td>{{ object.tech_c|linkify|placeholder }}</td>
         </tr>
         <tr>
-            <th scope="row">Billing Contact</th>
+            <th scope="row">{% trans "Billing Contact" %}</th>
             <td>{{ object.billing_c|linkify|placeholder }}</td>
         </tr>
     </table>

--- a/netbox_dns/templates/netbox_dns/zonetemplate.html
+++ b/netbox_dns/templates/netbox_dns/zonetemplate.html
@@ -3,27 +3,26 @@
 {% load plugins %}
 {% load render_table from django_tables2 %}
 {% load perms %}
+{% load i18n %}
 
 {% block content %}
 <div class="row">
     <div class="col col-md-6">
         <div class="card">
-            <h5 class="card-header">
-                Zone Template
-            </h5>
+            <h5 class="card-header">{% trans "Zone Template" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Name</th>
+                    <th scope="row">{% trans "Name" %}</th>
                     <td>{{ object.name }}</td>
                 </tr>
                 {% if object.description %}
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
                 <tr>
-                    <th scope="row">Tenant</th>
+                    <th scope="row">{% trans "Tenant" %}</th>
                     <td>
                         {% if object.tenant.group %}
                             {{ object.tenant.group|linkify }} /
@@ -32,7 +31,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Nameservers</th>
+                    <th scope="row">{% trans "Nameservers" %}</th>
                     <td>
                         <table>
                             {% for nameserver in object.nameservers.all %}
@@ -42,7 +41,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row">Description</th>
+                    <th scope="row">{% trans "Description" %}</th>
                     <td>{{ object.description }}</td>
                 </tr>
             </table>
@@ -53,34 +52,45 @@
     </div>
     <div class="col col-md-6">
         <div class="card">
-            <h5 class="card-header">Domain Registration</h5>
+            <h5 class="card-header">{% trans "Domain Registration" %}</h5>
             <table class="table table-hover attr-table">
                 <tr>
-                    <th scope="row">Registrar</th>
+                    <th scope="row">{% trans "Registrar" %}</th>
                     <td>{{ object.registrar|linkify|placeholder }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Registrant</th>
+                    <th scope="row">{% trans "Registrant" %}</th>
                     <td>{{ object.registrant|linkify|placeholder }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Administrative Contact</th>
+                    <th scope="row">{% trans "Administrative Contact" %}</th>
                     <td>{{ object.admin_c|linkify|placeholder }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Technical Contact</th>
+                    <th scope="row">{% trans "Technical Contact" %}</th>
                     <td>{{ object.tech_c|linkify|placeholder }}</td>
                 </tr>
                 <tr>
-                    <th scope="row">Billing Contact</th>
+                    <th scope="row">{% trans "Billing Contact" %}</th>
                     <td>{{ object.billing_c|linkify|placeholder }}</td>
                 </tr>
             </table>
             </div>
         </div>
     </div>
-    <div class="col col-md-12">
-      {% include 'inc/panel_table.html' with table=record_template_table heading="Record Templates" %}
-    </div>
+    {% if record_template_table %}
+        <div class="col col-md-12">
+            <div class="card">
+                {% if record_template_table.rows|length == 1 %}
+                    <h2 class="card-header">{% trans "Record Template" %}</h2>
+                {% else %}
+                    <h2 class="card-header">{% trans "Record Templates" %}</h2>
+                {% endif %}
+                <div class="table-responsive">
+                    {% render_table record_template_table 'inc/table.html' %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/netbox_dns/validators/dns_name.py
+++ b/netbox_dns/validators/dns_name.py
@@ -1,6 +1,7 @@
 import re
 
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
 
 from netbox.plugins.utils import get_plugin_config
 
@@ -55,7 +56,9 @@ def validate_fqdn(name, always_tolerant=False):
     regex = rf"^(\*|{label})(\.{zone_label})+\.?$"
 
     if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
-        raise ValidationError(f"{name} is not a valid fully qualified DNS host name")
+        raise ValidationError(
+            _("{name} is not a valid fully qualified DNS host name").format(name=name)
+        )
 
 
 def validate_rname(name, always_tolerant=False):
@@ -63,7 +66,7 @@ def validate_rname(name, always_tolerant=False):
     regex = rf"^(\*|{label})(\\\.{label})*(\.{zone_label}){{2,}}\.?$"
 
     if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
-        raise ValidationError(f"{name} is not a valid RNAME")
+        raise ValidationError(_("{name} is not a valid RName").format(name=name))
 
 
 def validate_generic_name(
@@ -76,7 +79,9 @@ def validate_generic_name(
     regex = rf"^([*@]|(\*\.)?{label}(\.{zone_label})*\.?)$"
 
     if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
-        raise ValidationError(f"{name} is not a valid DNS host name")
+        raise ValidationError(
+            _("{name} is not a valid DNS host name").format(name=name)
+        )
 
 
 def validate_domain_name(
@@ -97,4 +102,6 @@ def validate_domain_name(
         regex = rf"^{label}(\.{zone_label})*\.?$"
 
     if not re.match(regex, name, flags=re.IGNORECASE) or _has_invalid_double_dash(name):
-        raise ValidationError(f"{name} is not a valid DNS domain name")
+        raise ValidationError(
+            _("{name} is not a valid DNS domain name").format(name=name)
+        )

--- a/netbox_dns/validators/rfc2317.py
+++ b/netbox_dns/validators/rfc2317.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
 
 
 __all__ = (
@@ -11,15 +12,17 @@ __all__ = (
 def validate_prefix(prefix):
     if prefix.ip != prefix.cidr.ip:
         raise ValidationError(
-            f"{prefix} is not a valid prefix. Did you mean {prefix.cidr}?"
+            _("{prefix} is not a valid prefix. Did you mean {cidr}?").format(
+                prefix=prefix, cidr=prefix.cidr
+            )
         )
 
 
 def validate_ipv4(prefix):
     if prefix.version != 4:
-        raise ValidationError("RFC2317 requires an IPv4 prefix.")
+        raise ValidationError(_("RFC2317 requires an IPv4 prefix."))
 
 
 def validate_rfc2317(prefix):
     if prefix.prefixlen <= 24:
-        raise ValidationError("RFC2317 requires at least 25 bit prefix length.")
+        raise ValidationError(_("RFC2317 requires at least 25 bit prefix length."))

--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -1,5 +1,7 @@
 from dns import name as dns_name
 
+from django.utils.translation import gettext_lazy as _
+
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 from tenancy.views import ObjectContactsView
@@ -91,7 +93,7 @@ class NameServerZoneListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="Zones",
+        label=_("Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.zones.count(),
         hide_if_empty=True,
@@ -111,7 +113,7 @@ class NameServerSOAZoneListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="SOA Zones",
+        label=_("SOA Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.zones_soa.count(),
         hide_if_empty=True,

--- a/netbox_dns/views/record_template.py
+++ b/netbox_dns/views/record_template.py
@@ -46,9 +46,10 @@ class RecordTemplateView(generic.ObjectView):
         if instance.value != unicode_value:
             context["unicode_value"] = unicode_value
 
-        context["zone_template_table"] = ZoneTemplateDisplayTable(
-            data=instance.zone_templates.all()
-        )
+        if instance.zone_templates.exists():
+            context["zone_template_table"] = ZoneTemplateDisplayTable(
+                data=instance.zone_templates.all()
+            )
 
         return context
 

--- a/netbox_dns/views/registrar.py
+++ b/netbox_dns/views/registrar.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext as _
+
 from netbox.views import generic
 
 from utilities.views import ViewTab, register_model_view
@@ -75,7 +77,7 @@ class RegistrarZoneListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="Zones",
+        label=_("Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.zone_set.count(),
         hide_if_empty=True,

--- a/netbox_dns/views/registration_contact.py
+++ b/netbox_dns/views/registration_contact.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from django.utils.translation import gettext_lazy as _
 
 from netbox.views import generic
 
@@ -79,7 +80,7 @@ class RegistrationContactZoneListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="Zones",
+        label=_("Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: len(obj.zones),
         hide_if_empty=True,

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -1,4 +1,5 @@
 from utilities.views import ViewTab, register_model_view
+from django.utils.translation import gettext_lazy as _
 
 from netbox.views import generic
 from tenancy.views import ObjectContactsView
@@ -96,7 +97,7 @@ class ViewZoneListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="Zones",
+        label=_("Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.zone_set.count(),
         hide_if_empty=True,

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -1,5 +1,7 @@
 from dns import name as dns_name
 
+from django.utils.translation import gettext_lazy as _
+
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 from tenancy.views import ObjectContactsView
@@ -127,7 +129,7 @@ class ZoneRecordListView(generic.ObjectChildrenView):
     hide_if_empty = True
 
     tab = ViewTab(
-        label="Records",
+        label=_("Records"),
         permission="netbox_dns.view_record",
         badge=lambda obj: obj.record_count(managed=False),
         hide_if_empty=True,
@@ -149,7 +151,7 @@ class ZoneManagedRecordListView(generic.ObjectChildrenView):
     actions = {"changelog": {"view"}}
 
     tab = ViewTab(
-        label="Managed Records",
+        label=_("Managed Records"),
         permission="netbox_dns.view_record",
         badge=lambda obj: obj.record_count(managed=True),
         hide_if_empty=True,
@@ -170,7 +172,7 @@ class ZoneRFC2317ChildZoneListView(generic.ObjectChildrenView):
     template_name = "netbox_dns/zone/rfc2317_child_zone.html"
 
     tab = ViewTab(
-        label="RFC2317 Child Zones",
+        label=_("RFC2317 Child Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.rfc2317_child_zone_count(),
         hide_if_empty=True,
@@ -189,7 +191,7 @@ class ZoneChildZoneListView(generic.ObjectChildrenView):
     template_name = "netbox_dns/zone/child_zone.html"
 
     tab = ViewTab(
-        label="Child Zones",
+        label=_("Child Zones"),
         permission="netbox_dns.view_zone",
         badge=lambda obj: obj.child_zones.count(),
         hide_if_empty=True,

--- a/netbox_dns/views/zone_template.py
+++ b/netbox_dns/views/zone_template.py
@@ -33,13 +33,14 @@ class ZoneTemplateView(generic.ObjectView):
     queryset = ZoneTemplate.objects.all()
 
     def get_extra_context(self, request, instance):
-        record_template_table = RecordTemplateDisplayTable(
-            data=instance.record_templates.all()
-        )
+        if instance.record_templates.exists():
+            return {
+                "record_template_table": RecordTemplateDisplayTable(
+                    data=instance.record_templates.all()
+                )
+            }
 
-        return {
-            "record_template_table": record_template_table,
-        }
+        return {}
 
 
 class ZoneTemplateEditView(generic.ObjectEditView):


### PR DESCRIPTION
fixes #412

This PR adds internationalisation support via `gettext`. All (I hope) user-visible strings have been wrapped in `gettext()` methods and an initial language file for German has been added.