### PR TITLE
Added validation for TXT and SRV record values, and help with adding them to a zone

### DIFF
--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -598,7 +598,7 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
     def validate_value(self):
         try:
-            validate_record_value(self.type, self.value)
+            validate_record_value(self)
         except ValidationError as exc:
             raise ValidationError({"value": exc})
 

--- a/netbox_dns/models/record_template.py
+++ b/netbox_dns/models/record_template.py
@@ -137,7 +137,7 @@ class RecordTemplate(NetBoxModel):
 
     def validate_value(self):
         try:
-            validate_record_value(self.type, self.value)
+            validate_record_value(self)
         except ValidationError as exc:
             raise ValidationError({"value": exc}) from None
 


### PR DESCRIPTION
fixes #423

* Validate the value for `TXT` and `SPF` records to ensure they are printable ASCII strings.
* If the length of the value for these record types exceeds the maximum allowed by `dnspython`, break it in multiple parts and validate the result again