### PR TITLE
Made tests more compatible with NetBox 4.0

### DIFF
--- a/netbox_dns/tests/custom.py
+++ b/netbox_dns/tests/custom.py
@@ -5,9 +5,15 @@ import strawberry_django
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
-from strawberry.types.base import StrawberryList, StrawberryOptional
-from strawberry.types.union import StrawberryUnion
-from strawberry.types.lazy_type import LazyType
+try:
+    from strawberry.types.base import StrawberryList, StrawberryOptional
+    from strawberry.types.union import StrawberryUnion
+    from strawberry.types.lazy_type import LazyType
+except ImportError:
+    from strawberry.type import StrawberryList, StrawberryOptional
+    from strawberry.union import StrawberryUnion
+    from strawberry.lazy_type import LazyType
+
 
 from ipam.graphql.types import IPAddressFamilyType
 from utilities.testing.api import APITestCase as NetBoxAPITestCase

--- a/netbox_dns/tests/test_netbox_dns.py
+++ b/netbox_dns/tests/test_netbox_dns.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from django.test import SimpleTestCase
 
 from netbox_dns import __version__
-from netbox_dns.tests.custom import APITestCase
+from utilities.testing.api import APITestCase
 
 
 class NetBoxDNSVersionTestCase(SimpleTestCase):


### PR DESCRIPTION
Some GraphQL tests are still failing, but that's probably not something that can be fixed in NetBox DNS. I'll investigate further, but with low priority.