### PR TITLE
Added a warning when a record in a zone may be masked from view by a child zone

### DIFF
--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -263,7 +263,7 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
     @property
     def value_fqdn(self):
-        if self.type != RecordTypeChoices.CNAME:
+        if self.type not in (RecordTypeChoices.CNAME, RecordTypeChoices.NS):
             return None
 
         _zone = dns_name.from_text(self.zone.name)
@@ -345,6 +345,10 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         )
 
         return ptr_zone
+
+    @property
+    def is_glue(self):
+        return self in self.zone.glue_records
 
     def update_ptr_record(self, update_rfc2317_cname=True, save_zone_serial=True):
         ptr_zone = self.ptr_zone

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -43,6 +43,12 @@
                     <th scope="row">{% trans "Name" %}</th>
                     <td style="word-break:break-all;">{{ object.name }}</td>
                 </tr>
+                {% if mask_warning %}
+                <tr class="text-warning">
+                    <th scope="row">{% trans "Warning" %}</th>
+                    <td>{{ mask_warning }}</td>
+                </tr>
+                {% endif %}
                 {% if unicode_name %}
                 <tr>
                     <th scope="row">{% trans "IDN" %}</th>

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -139,6 +139,19 @@ class RecordView(generic.ObjectView):
         else:
             context["cname_table"] = self.get_cname_records(instance)
 
+        fqdn = dns_name.from_text(instance.fqdn)
+        name = dns_name.from_text(instance.name, origin=None)
+
+        if len(name) > 1 and not instance.is_glue:
+            if Zone.objects.filter(
+                name__in=get_parent_zone_names(
+                    instance.fqdn, min_labels=len(fqdn) - len(name)
+                )
+            ).exists():
+                context["mask_warning"] = _(
+                    "Record is masked by a child zone and may not be visible in DNS"
+                )
+
         return context
 
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -144,9 +144,10 @@ class RecordView(generic.ObjectView):
 
         if len(name) > 1 and not instance.is_glue:
             if Zone.objects.filter(
+                active=True,
                 name__in=get_parent_zone_names(
                     instance.fqdn, min_labels=len(fqdn) - len(name)
-                )
+                ),
             ).exists():
                 context["mask_warning"] = _(
                     "Record is masked by a child zone and may not be visible in DNS"

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -139,19 +139,21 @@ class RecordView(generic.ObjectView):
         else:
             context["cname_table"] = self.get_cname_records(instance)
 
-        fqdn = dns_name.from_text(instance.fqdn)
-        name = dns_name.from_text(instance.name, origin=None)
+        if not instance.managed:
+            name = dns_name.from_text(instance.name, origin=None)
 
-        if len(name) > 1 and not instance.is_glue:
-            if Zone.objects.filter(
-                active=True,
-                name__in=get_parent_zone_names(
-                    instance.fqdn, min_labels=len(fqdn) - len(name)
-                ),
-            ).exists():
-                context["mask_warning"] = _(
-                    "Record is masked by a child zone and may not be visible in DNS"
-                )
+            if len(name) > 1 and not instance.is_glue:
+                fqdn = dns_name.from_text(instance.fqdn)
+
+                if Zone.objects.filter(
+                    active=True,
+                    name__in=get_parent_zone_names(
+                        instance.fqdn, min_labels=len(fqdn) - len(name)
+                    ),
+                ).exists():
+                    context["mask_warning"] = _(
+                        "Record is masked by a child zone and may not be visible in DNS"
+                    )
 
         return context
 


### PR DESCRIPTION
fixes #445 

This PR warns when the user creates a record in a parent zone that actually defines a name in a child zone, e.g. if zones `example.com` and `zone1.example.com` exist and a record with the name `name1.zone1` is created in zone `example.com`.

Glue records are exempt from this warning, as they are necessary to avoid infinite lookup loops.