### PR TITLE
Do not warn about masking  for DS records in parent zones

### DIFF
--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -347,8 +347,8 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         return ptr_zone
 
     @property
-    def is_glue(self):
-        return self in self.zone.glue_records
+    def is_delegation_record(self):
+        return self in self.zone.delegation_records
 
     def update_ptr_record(self, update_rfc2317_cname=True, save_zone_serial=True):
         ptr_zone = self.ptr_zone

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -142,13 +142,15 @@ class RecordView(generic.ObjectView):
         if not instance.managed:
             name = dns_name.from_text(instance.name, origin=None)
 
-            if len(name) > 1 and not instance.is_delegation_record:
+            if not instance.is_delegation_record:
                 fqdn = dns_name.from_text(instance.fqdn)
 
                 if Zone.objects.filter(
                     active=True,
                     name__in=get_parent_zone_names(
-                        instance.fqdn, min_labels=len(fqdn) - len(name)
+                        instance.fqdn,
+                        min_labels=len(fqdn) - len(name),
+                        include_self=True,
                     ),
                 ).exists():
                     context["mask_warning"] = _(

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -142,7 +142,7 @@ class RecordView(generic.ObjectView):
         if not instance.managed:
             name = dns_name.from_text(instance.name, origin=None)
 
-            if len(name) > 1 and not instance.is_glue:
+            if len(name) > 1 and not instance.is_delegation_record:
                 fqdn = dns_name.from_text(instance.fqdn)
 
                 if Zone.objects.filter(


### PR DESCRIPTION
fixes #449 

Do not warn when a DS record with the name of a child zone is added to the parent zone. This is a correct and necessary record in the parent zone, not a potential error.