### PR TITLE
Improved rendering of the address record links

### DIFF
--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -121,7 +121,12 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
 address_records = tables.ManyToManyColumn(
     verbose_name="DNS Address Records",
     accessor="netbox_dns_records",
-    linkify=True,
+    linkify_item=True,
+    transform=lambda obj: (
+        obj.fqdn.rstrip(".")
+        if obj.zone.view.default_view
+        else f"[{obj.zone.view.name}] {obj.fqdn.rstrip('.')}"
+    ),
 )
 
 if not settings.PLUGINS_CONFIG["netbox_dns"].get("dnssync_disabled"):


### PR DESCRIPTION
The first implementation of the new table column lacked the information in which view an address record's zone is located. While the type of the record (`A` vs. `AAAA`) is quite irrelevant as it's determined by the address family of the IP Address, the view information is relevant.