### PR TITLE
Reduced complexity of some queries

### DIFF
--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -71,7 +71,7 @@ class NameServerViewSet(NetBoxModelViewSet):
 
 
 class RecordViewSet(NetBoxModelViewSet):
-    queryset = Record.objects.all().prefetch_related("zone", "zone__view", "tenant")
+    queryset = Record.objects.prefetch_related("zone", "zone__view", "tenant")
     serializer_class = RecordSerializer
     filterset_class = RecordFilterSet
 

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -187,11 +187,9 @@ class RecordImportForm(NetBoxModelImportForm):
                 pass
 
         if view is not None:
-            self.fields["zone"].queryset = Zone.objects.filter(view=view)
+            self.fields["zone"].queryset = view.zone_set
         else:
-            self.fields["zone"].queryset = Zone.objects.filter(
-                view=View.get_default_view()
-            )
+            self.fields["zone"].queryset = View.get_default_view().zone_set
 
     zone = CSVModelChoiceField(
         queryset=Zone.objects.all(),

--- a/netbox_dns/forms/view.py
+++ b/netbox_dns/forms/view.py
@@ -302,7 +302,7 @@ class ViewPrefixEditForm(forms.ModelForm):
 
         if not views.exists():
             if (parent := prefix.get_parents().last()) is not None:
-                check_views = parent.netbox_dns_views.all().difference(old_views)
+                check_views = parent.netbox_dns_views.difference(old_views)
 
         else:
             check_views = views.difference(old_views)

--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -112,10 +112,8 @@ class NameServer(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
     def delete(self, *args, **kwargs):
         with transaction.atomic():
-            zones = self.zones.all()
-            for zone in zones:
-                Record.objects.filter(
-                    Q(zone=zone),
+            for zone in self.zones.all():
+                zone.record_set.filter(
                     Q(managed=True),
                     Q(value=f"{self.name}."),
                     Q(type=RecordTypeChoices.NS),

--- a/netbox_dns/models/record_template.py
+++ b/netbox_dns/models/record_template.py
@@ -142,8 +142,8 @@ class RecordTemplate(NetBoxModel):
             raise ValidationError({"value": exc})
 
     def matching_records(self, zone):
-        return Record.objects.filter(
-            zone=zone, name=self.record_name, type=self.type, value=self.value
+        return zone.record_set.filter(
+            name=self.record_name, type=self.type, value=self.value
         )
 
     def create_record(self, zone):

--- a/netbox_dns/utilities/ipam_dnssync.py
+++ b/netbox_dns/utilities/ipam_dnssync.py
@@ -193,9 +193,7 @@ def update_dns_records(ip_address, view=None, force=False):
                     updated = True
 
         zones = Zone.objects.filter(pk__in=[zone.pk for zone in zones]).exclude(
-            pk__in=set(
-                ip_address.netbox_dns_records.all().values_list("zone", flat=True)
-            )
+            pk__in=set(ip_address.netbox_dns_records.values_list("zone", flat=True))
         )
 
     for zone in zones:

--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -36,7 +36,7 @@ class NameServerListView(generic.ObjectListView):
 
 
 class NameServerView(generic.ObjectView):
-    queryset = NameServer.objects.all().prefetch_related("zones")
+    queryset = NameServer.objects.prefetch_related("zones")
 
     def get_extra_context(self, request, instance):
         name = dns_name.from_text(instance.name)
@@ -85,7 +85,7 @@ class NameServerContactsView(ObjectContactsView):
 
 @register_model_view(NameServer, "zones")
 class NameServerZoneListView(generic.ObjectChildrenView):
-    queryset = NameServer.objects.all().prefetch_related("zones")
+    queryset = NameServer.objects.prefetch_related("zones")
     child_model = Zone
     table = ZoneTable
     filterset = ZoneFilterSet
@@ -105,7 +105,7 @@ class NameServerZoneListView(generic.ObjectChildrenView):
 
 @register_model_view(NameServer, "soa_zones")
 class NameServerSOAZoneListView(generic.ObjectChildrenView):
-    queryset = NameServer.objects.all().prefetch_related("zones_soa")
+    queryset = NameServer.objects.prefetch_related("zones_soa")
     child_model = Zone
     table = ZoneTable
     filterset = ZoneFilterSet

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -56,7 +56,7 @@ class ManagedRecordListView(generic.ObjectListView):
 
 
 class RecordView(generic.ObjectView):
-    queryset = Record.objects.all().prefetch_related("zone", "ptr_record")
+    queryset = Record.objects.prefetch_related("zone", "ptr_record")
 
     def get_value_records(self, instance):
         value_fqdn = dns_name.from_text(instance.value_fqdn)
@@ -70,9 +70,8 @@ class RecordView(generic.ObjectView):
                 data=cname_targets,
             )
 
-        if Zone.objects.filter(
+        if instance.zone.view.zone_set.filter(
             name__in=get_parent_zone_names(instance.value_fqdn, min_labels=1),
-            view=instance.zone.view,
             active=True,
         ).exists():
             raise (
@@ -94,8 +93,7 @@ class RecordView(generic.ObjectView):
             )
         )
 
-        parent_zones = Zone.objects.filter(
-            view=instance.zone.view,
+        parent_zones = instance.zone.view.zone_set.filter(
             name__in=get_parent_zone_names(instance.fqdn, include_self=True),
         )
 

--- a/netbox_dns/views/registrar.py
+++ b/netbox_dns/views/registrar.py
@@ -69,7 +69,7 @@ class RegistrarBulkDeleteView(generic.BulkDeleteView):
 
 @register_model_view(Registrar, "zones")
 class RegistrarZoneListView(generic.ObjectChildrenView):
-    queryset = Registrar.objects.all().prefetch_related("zone_set")
+    queryset = Registrar.objects.prefetch_related("zone_set")
     child_model = Zone
     table = ZoneTable
     filterset = ZoneFilterSet

--- a/netbox_dns/views/registration_contact.py
+++ b/netbox_dns/views/registration_contact.py
@@ -70,7 +70,7 @@ class RegistrationContactBulkDeleteView(generic.BulkDeleteView):
 
 @register_model_view(RegistrationContact, "zones")
 class RegistrationContactZoneListView(generic.ObjectChildrenView):
-    queryset = RegistrationContact.objects.all().prefetch_related(
+    queryset = RegistrationContact.objects.prefetch_related(
         "zone_set", "admin_c_zones", "tech_c_zones", "billing_c_zones"
     )
     child_model = Zone

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -31,7 +31,7 @@ __all__ = (
 
 
 class ViewView(generic.ObjectView):
-    queryset = View.objects.all().prefetch_related("zone_set")
+    queryset = View.objects.prefetch_related("zone_set")
 
 
 class ViewListView(generic.ObjectListView):
@@ -89,7 +89,7 @@ class ViewPrefixEditView(generic.ObjectEditView):
 
 @register_model_view(View, "zones")
 class ViewZoneListView(generic.ObjectChildrenView):
-    queryset = View.objects.all().prefetch_related("zone_set")
+    queryset = View.objects.prefetch_related("zone_set")
     child_model = Zone
     table = ZoneTable
     filterset = ZoneFilterSet

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -33,14 +33,14 @@ __all__ = (
 
 
 class ZoneListView(generic.ObjectListView):
-    queryset = Zone.objects.all().prefetch_related("view", "tags")
+    queryset = Zone.objects.prefetch_related("view", "tags")
     filterset = ZoneFilterSet
     filterset_form = ZoneFilterForm
     table = ZoneTable
 
 
 class ZoneView(generic.ObjectView):
-    queryset = Zone.objects.all().prefetch_related(
+    queryset = Zone.objects.prefetch_related(
         "view",
         "tags",
         "nameservers",
@@ -65,9 +65,7 @@ class ZoneView(generic.ObjectView):
 
 
 class ZoneEditView(generic.ObjectEditView):
-    queryset = Zone.objects.all().prefetch_related(
-        "view", "tags", "nameservers", "soa_mname"
-    )
+    queryset = Zone.objects.prefetch_related("view", "tags", "nameservers", "soa_mname")
     form = ZoneForm
     default_return_url = "plugins:netbox_dns:zone_list"
 
@@ -78,18 +76,14 @@ class ZoneDeleteView(generic.ObjectDeleteView):
 
 
 class ZoneBulkImportView(generic.BulkImportView):
-    queryset = Zone.objects.all().prefetch_related(
-        "view", "tags", "nameservers", "soa_mname"
-    )
+    queryset = Zone.objects.prefetch_related("view", "tags", "nameservers", "soa_mname")
     model_form = ZoneImportForm
     table = ZoneTable
     default_return_url = "plugins:netbox_dns:zone_list"
 
 
 class ZoneBulkEditView(generic.BulkEditView):
-    queryset = Zone.objects.all().prefetch_related(
-        "view", "tags", "nameservers", "soa_mname"
-    )
+    queryset = Zone.objects.prefetch_related("view", "tags", "nameservers", "soa_mname")
     filterset = ZoneFilterSet
     table = ZoneTable
     form = ZoneBulkEditForm
@@ -131,14 +125,12 @@ class ZoneRecordListView(generic.ObjectChildrenView):
     tab = ViewTab(
         label=_("Records"),
         permission="netbox_dns.view_record",
-        badge=lambda obj: obj.record_count(managed=False),
+        badge=lambda obj: obj.record_set.filter(managed=False).count(),
         hide_if_empty=True,
     )
 
     def get_children(self, request, parent):
-        return Record.objects.restrict(request.user, "view").filter(
-            zone=parent, managed=False
-        )
+        return parent.record_set.restrict(request.user, "view").filter(managed=False)
 
 
 @register_model_view(Zone, "managed_records")
@@ -153,14 +145,12 @@ class ZoneManagedRecordListView(generic.ObjectChildrenView):
     tab = ViewTab(
         label=_("Managed Records"),
         permission="netbox_dns.view_record",
-        badge=lambda obj: obj.record_count(managed=True),
+        badge=lambda obj: obj.record_set.filter(managed=True).count(),
         hide_if_empty=True,
     )
 
     def get_children(self, request, parent):
-        return Record.objects.restrict(request.user, "view").filter(
-            zone=parent, managed=True
-        )
+        return parent.record_set.restrict(request.user, "view").filter(managed=True)
 
 
 @register_model_view(Zone, "rfc2317_child_zones")
@@ -174,7 +164,7 @@ class ZoneRFC2317ChildZoneListView(generic.ObjectChildrenView):
     tab = ViewTab(
         label=_("RFC2317 Child Zones"),
         permission="netbox_dns.view_zone",
-        badge=lambda obj: obj.rfc2317_child_zone_count(),
+        badge=lambda obj: obj.rfc2317_child_zones.count(),
         hide_if_empty=True,
     )
 


### PR DESCRIPTION
Cleaned up some queries by removing redundant `.all()` terms and replaced some queries with variants based on related sets.

This also should have the advantage of playing more smoothly with the branching plugin (just a guess, but I assume that a global query needs some attention to use the current branch while the related object set is assumed to be branch aware.

Even if that's not correct it's less code :-)