### PR TITLE
Fixed change detection for custom fields

### DIFF
--- a/netbox_dns/mixins/object_modification.py
+++ b/netbox_dns/mixins/object_modification.py
@@ -21,6 +21,10 @@ class ObjectModificationMixin:
 
     def _save_field_values(self):
         for field in self.check_fields:
+            if field == "custom_field_data":
+                self._saved_custom_field_data = self.custom_field_data.copy()
+                continue
+
             if f"{field}_id" in self.__dict__:
                 setattr(self, f"_saved_{field}_id", self.__dict__.get(f"{field}_id"))
             else:

--- a/netbox_dns/tests/record/test_custom_field_changes.py
+++ b/netbox_dns/tests/record/test_custom_field_changes.py
@@ -1,0 +1,85 @@
+import re
+import textwrap
+
+from django.test import TestCase
+
+from core.models import ObjectType
+from extras.models import CustomField
+from extras.choices import CustomFieldTypeChoices
+
+from netbox_dns.models import Zone, Record, NameServer
+from netbox_dns.choices import RecordTypeChoices
+
+
+def split_text_value(value):
+    raw_value = "".join(re.findall(r'"([^"]+)"', value))
+    if not raw_value:
+        raw_value = value
+
+    return " ".join(
+        f'"{part}"' for part in textwrap.wrap(raw_value, 255, drop_whitespace=False)
+    )
+
+
+class RecordCustomFieldTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        nameserver = NameServer.objects.create(name="ns1.example.com")
+
+        zone = Zone.objects.create(
+            name="zone1.example.com",
+            soa_mname=nameserver,
+            soa_rname="hostmaster.example.com",
+        )
+
+        cls.records = [
+            Record(
+                zone=zone,
+                name="test1",
+                type=RecordTypeChoices.A,
+                value="10.0.1.42",
+            ),
+            Record(
+                zone=zone,
+                name="test2",
+                type=RecordTypeChoices.AAAA,
+                value="fe80:dead:beef::1:42",
+            ),
+            Record(
+                zone=zone,
+                name="test3",
+                type=RecordTypeChoices.TXT,
+                value="this is a test record",
+            ),
+        ]
+        for record in cls.records:
+            record.save()
+
+        cf = CustomField.objects.create(
+            name="test_cf",
+            label="Test CF",
+            type=CustomFieldTypeChoices.TYPE_INTEGER,
+            required=False,
+        )
+        cf.object_types.set([ObjectType.objects.get_for_model(Record)])
+
+    def test_custom_field_set(self):
+        for record in self.records:
+            record.custom_field_data["test_cf"] = 42
+            record.save()
+
+            record.refresh_from_db()
+
+            self.assertEqual(record.custom_field_data.get("test_cf"), 42)
+
+    def test_custom_field_modify(self):
+        for record in self.records:
+            record.custom_field_data["test_cf"] = 42
+            record.save()
+
+            record.custom_field_data["test_cf"] = 23
+            record.save()
+
+            record.refresh_from_db()
+
+            self.assertEqual(record.custom_field_data.get("test_cf"), 23)


### PR DESCRIPTION
fixes #472

Changes to custom fields were not detected by `ObjectChangeMixin` because `custom_field_data` only contains a reference to a dictionary and only the reference was saved, not the dictionary itself.