### PR TITLE
Run delete() for nameserver objects, not a queryset on removal

### DIFF
--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -497,9 +497,10 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
         nameservers = [f"{nameserver.name}." for nameserver in self.nameservers.all()]
 
-        self.records.filter(type=RecordTypeChoices.NS, managed=True).exclude(
-            value__in=nameservers
-        ).delete()
+        for ns_record in self.records.filter(
+            type=RecordTypeChoices.NS, managed=True
+        ).exclude(value__in=nameservers):
+            ns_record.delete()
 
         for ns in nameservers:
             Record.raw_objects.update_or_create(


### PR DESCRIPTION
fixes #476 