### PR TITLE
Provided slightly more detailed debugging for rebuild_dnssync

### DIFF
--- a/netbox_dns/management/commands/rebuild_dnssync.py
+++ b/netbox_dns/management/commands/rebuild_dnssync.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 
 from ipam.models import IPAddress
 
-from netbox_dns.utilities import update_dns_records
+from netbox_dns.utilities import update_dns_records, get_zones
 
 
 class Command(BaseCommand):
@@ -22,6 +22,8 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Updating DNS records for IP Address {ip_address}, VRF {ip_address.vrf}"
                 )
+            if options.get("verbosity") >= 3:
+                self.stdout.write(f"  Zones: {get_zones(ip_address)}")
             if (
                 update_dns_records(ip_address, force=options.get("force"))
                 and options.get("verbosity") >= 1


### PR DESCRIPTION
Get a list of candidate zones for IP addresses with IPAM DNSsync (use `--verbosity 3`) when running the `rebuild_dnssync` management command.