### PR TITLE
docs(issues): use markdown semantic tag for issues titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,29 +7,36 @@ assignees: ''
 
 ---
 
-**Versions**
+## Versions
+
 NetBox Version: x.x.x
 NetBox DNS Version: x.x.x
 Python Version: x.x.x
 
-**Describe the bug**
+## Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected result**
+## Expected result
+
 A clear and concise description of what you expected to happen.
 
-**Actual result**
+## Actual result
+
 A clear and concise description of what happens instead. If there are any exceptions or errors in the logs please provide them as well.
 
-**Screenshots**
+## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Code Examples**
+## Code Examples
+
 If applicable, please provide ideally minimal code example of code that is causing the problem to happen. The more concise the example is, the less effort it is to find a problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Hello, 

I propose to improve slightly issues templates by using native title tags (## => h2) instead of bold (**), which make templates more standard and accessible. 

Thks you for the job. 