### PR TITLE
Check whether dns_name set before running post_clean on IP addresses

### DIFF
--- a/netbox_dns/signals/ipam_dnssync.py
+++ b/netbox_dns/signals/ipam_dnssync.py
@@ -35,6 +35,9 @@ ENFORCE_UNIQUE_RECORDS = settings.PLUGINS_CONFIG["netbox_dns"]["enforce_unique_r
 
 @receiver(post_clean, sender=IPAddress)
 def ipam_dnssync_ipaddress_post_clean(instance, **kwargs):
+    if not instance.dns_name:
+        return
+
     if not isinstance(instance.address, IPNetwork):
         return
 


### PR DESCRIPTION
fixes #488

This PR fixes an issue with the validation of DNS names for IP addresses with DNSsync.

When bulk-importing a duplicate IP address that would violate a uniqueness constraint (either set per prefix or via `ENFORCE_GLOBAL_UNIQUE`), the `post_clean` handler for NetBox DNS is apparently run before the duplicate check in NetBox is executed. This causes NetBox DNS to check for duplicate address records, and even if the DNS name is empty for the duplicate records this will result in an error message stating that there are duplicate records for the IP address.

This is OK if DNS names have actually been set and are the same, but if there are none the error message is erroneous and should not be raised as it covers the real reason for the failed import.