### PR TITLE
Accept leading underscores in CNAME and DNAME record names

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -375,7 +375,7 @@ After changing the configuration, NetBox must be restarted for the changes to ta
 The detail view for zones can provide additional information tabs about zones, depending on whether there are any objects to display:
 
 Tab name                       | Description
---------                       | --------           
+--------                       | --------
 **Records**                    | Provides a list of all (non-managed) records in the zone.
 **Managed Records**            | Provides a list of all managed records in the zone.
 **Delegation Records**         | If there are any delegation records (NS, DS or glue address records) for child zones in the zone, this tab lists them.
@@ -651,7 +651,7 @@ Variable                            | Factory Default
 --------                            | ---------------
 `tolerate_underscores_in_labels`    | `False`
 `tolerate_characters_in_zone_labels`| `''`
-`tolerate_leading_underscore_types` | `["TXT", "SRV", "TLSA"]`
+`tolerate_leading_underscore_types` | `["TXT", "SRV", "TLSA", "CNAME", "DNAME"]`
 `tolerate_non_rfc1035_types`        | `[]`
 
 The settings can be set or overridden in the file `/opt/netbox/netbox/netbox/configuration.py` by defining new values in `PLUGINS_CONFIG` as follows:
@@ -662,7 +662,7 @@ PLUGINS_CONFIG = {
         ...
         'tolerate_underscores_in_labels': True,
         'tolerate_characters_in_zone_labels': "/",
-        'tolerate_leading_underscore_types': ["TXT", "SRV", "TLSA", "CNAME"]
+        'tolerate_leading_underscore_types': ["TXT", "SRV", "TLSA", "CNAME", "DNAME", "MX"]
         'tolerate_non_rfc1035_types': ["X25"]
     },
 }

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -51,6 +51,8 @@ class DNSConfig(PluginConfig):
         "tolerate_underscores_in_labels": False,
         "tolerate_underscores_in_hostnames": False,  # Deprecated, will be removed in 1.2.0
         "tolerate_leading_underscore_types": [
+            RecordTypeChoices.CNAME,
+            RecordTypeChoices.DNAME,
             RecordTypeChoices.SRV,
             RecordTypeChoices.TLSA,
             RecordTypeChoices.TXT,

--- a/netbox_dns/tests/record/test_validation.py
+++ b/netbox_dns/tests/record/test_validation.py
@@ -530,6 +530,18 @@ class RecordValidationTestCase(TestCase):
                 type=RecordTypeChoices.SVCB,
                 value="1 svc.example.com.",
             ),
+            Record(
+                name="_name17",
+                zone=f_zone,
+                type=RecordTypeChoices.DNAME,
+                value="_name17a.example.com.",
+            ),
+            Record(
+                name="_name18",
+                zone=f_zone,
+                type=RecordTypeChoices.CNAME,
+                value="_name18a.example.com.",
+            ),
         )
 
         for record in records:


### PR DESCRIPTION
fixes #494 

This is a solution to a concrete problem reported in the issue mentioned above. While probably not the final generic solution, it at least eliminates a problem with a fairly common use case.