### PR TITLE
Added a configuration option to disable the creation of selected record types

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -410,7 +410,7 @@ For records the following fields are defined:
 Field           | Required | Explanation
 -----           | -------- | -----------
 **Zone**        | Yes      | The zone in which the record is to be defined
-**Type**        | Yes      | The type of the resource record. This can be one of a list of record types derived from [RFC 1035, Section 3.3](https://datatracker.ietf.org/doc/html/rfc1035#section-3.3), e.g. A or AAAA
+**Type**        | Yes      | The type of the resource record. This can be one of a list of record types derived from [RFC 1035, Section 3.3](https://datatracker.ietf.org/doc/html/rfc1035#section-3.3), e.g. A or AAAA. The list of record types can be limited using the configuration variable `filter_record_types`.
 **Disable PTR** | Yes      | A checkbox indicating whether a PTR record should be generated for an A or AAAA record automatically if there is a zone suitable for the PTR in NetBox DNS
 **Name**        | Yes      | The name of the record, e.g. the simple host name for A and AAAA records
 **Value**       | Yes      | The value of the record, e.g. the IPv4 or IPv6 addreess
@@ -450,6 +450,20 @@ Records can either be displayed by opening the record list view from the "Record
 
 #### Importing records
 When importing records in bulk, the mandatory fields are `name`, `zone`, `type` and `value`. If the optional `view` field is not specified, NetBox DNS will always look for the zone specified in `zone` in the default view. To address zones in non-default views, the `view` field must also be specified.
+
+#### Configuration options
+The configuration variable `filter_record_types` can be used to limit the list of record types that are available in the GUI forms. For example if you are tired of IPv4 the creation of `A` records can be disabled by setting
+
+```
+PLUGINS_CONFIG = {
+    "netbox_dns": {
+        ...
+        "filter_record_types": [ "A" ],
+        ...
+    }
+}
+```
+
 ### Registrars
 Registrar objects relate to the DNS domain registration and represent the registrar information for DNS domains related to zones. A DNS zone does not necessarily need to be registered: Zones that are not available via public DNS or that are sub-zones of registered zones do not require registration. In most cases registration information is only required (and possible) for second-level domains.
 

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -36,6 +36,7 @@ class DNSConfig(PluginConfig):
             ZoneStatusChoices.STATUS_ACTIVE,
             ZoneStatusChoices.STATUS_DYNAMIC,
         ],
+        "filter_record_types": [],
         "record_active_status": [
             RecordStatusChoices.STATUS_ACTIVE,
         ],

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -21,7 +21,7 @@ from tenancy.models import Tenant, TenantGroup
 from tenancy.forms import TenancyForm, TenancyFilterForm
 
 from netbox_dns.models import View, Zone, Record
-from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
+from netbox_dns.choices import RecordSelectableTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode
 
 
@@ -56,6 +56,11 @@ class RecordForm(TenancyForm, NetBoxModelForm):
             "view_id": "$view",
         },
         label=_("Zone"),
+    )
+    type = forms.ChoiceField(
+        choices=add_blank_choice(RecordSelectableTypeChoices),
+        required=True,
+        label=_("Type"),
     )
 
     disable_ptr = forms.BooleanField(
@@ -123,7 +128,7 @@ class RecordFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     )
 
     type = forms.MultipleChoiceField(
-        choices=RecordTypeChoices,
+        choices=RecordSelectableTypeChoices,
         required=False,
         label=_("Type"),
     )
@@ -210,7 +215,7 @@ class RecordImportForm(NetBoxModelImportForm):
         help_text=_("This field is required if the zone is not in the default view"),
     )
     type = CSVChoiceField(
-        choices=RecordTypeChoices,
+        choices=RecordSelectableTypeChoices,
         required=True,
         label=_("Type"),
     )
@@ -268,7 +273,7 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
         label=_("Zone"),
     )
     type = forms.ChoiceField(
-        choices=add_blank_choice(RecordTypeChoices),
+        choices=add_blank_choice(RecordSelectableTypeChoices),
         required=False,
         label=_("Type"),
     )

--- a/netbox_dns/forms/record_template.py
+++ b/netbox_dns/forms/record_template.py
@@ -21,7 +21,7 @@ from tenancy.models import Tenant, TenantGroup
 from tenancy.forms import TenancyForm, TenancyFilterForm
 
 from netbox_dns.models import RecordTemplate, ZoneTemplate
-from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices
+from netbox_dns.choices import RecordSelectableTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode
 
 
@@ -41,6 +41,11 @@ class RecordTemplateForm(TenancyForm, NetBoxModelForm):
         if initial_record_name:
             self.initial["record_name"] = name_to_unicode(initial_record_name)
 
+    type = forms.ChoiceField(
+        choices=add_blank_choice(RecordSelectableTypeChoices),
+        required=True,
+        label=_("Type"),
+    )
     disable_ptr = forms.BooleanField(
         required=False,
         label=_("Disable PTR"),
@@ -103,7 +108,7 @@ class RecordTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     )
 
     type = forms.MultipleChoiceField(
-        choices=RecordTypeChoices,
+        choices=RecordSelectableTypeChoices,
         required=False,
         label=_("Type"),
     )
@@ -142,7 +147,7 @@ class RecordTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 
 class RecordTemplateImportForm(NetBoxModelImportForm):
     type = CSVChoiceField(
-        choices=RecordTypeChoices,
+        choices=RecordSelectableTypeChoices,
         required=True,
         label=_("Type"),
     )
@@ -187,7 +192,7 @@ class RecordTemplateBulkEditForm(NetBoxModelBulkEditForm):
     model = RecordTemplate
 
     type = forms.ChoiceField(
-        choices=add_blank_choice(RecordTypeChoices),
+        choices=add_blank_choice(RecordSelectableTypeChoices),
         required=False,
         label=_("Type"),
     )


### PR DESCRIPTION
fixes #521

This PR introduces the `filter_record_types` configuration setting which defines a list of record types to be left out from the selection menus in the GUI.

By default the list is empty. If RR types are listed in the setting's value (which needs to be a list of strings), these types are excluded from the selection when records or record templates are created, updated, filtered etc.

Existing records or records created by the plugin itself are not affected by this filter.