### PR TITLE
Disallow names that can be interpreted as IPv4 addresses (RFC 1912)

### DIFF
--- a/netbox_dns/tests/zone/test_name_validation.py
+++ b/netbox_dns/tests/zone/test_name_validation.py
@@ -53,6 +53,8 @@ class ZoneNameValidationTestCase(TestCase):
             + ".example.com.",  # 256 octets, trailing dot
             ".",  # root zone
             "0/25.2.0.192.in-addr.arpa",  # RFC 2317 sample zone including "/"
+            "10.0.0.42",  # Name is interpreted as IP address by inet_aton
+            "0x2a",  # Name is interpreted as IP address by inet_aton
         )
 
         for name in names:

--- a/netbox_dns/validators/dns_name.py
+++ b/netbox_dns/validators/dns_name.py
@@ -1,4 +1,5 @@
 import re
+from socket import inet_aton
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
@@ -94,6 +95,14 @@ def validate_domain_name(
         always_tolerant or get_plugin_config("netbox_dns", "enable_root_zones")
     ):
         return
+
+    try:
+        inet_aton(name)
+        raise ValidationError(
+            _("{name} is not a valid DNS domain name").format(name=name)
+        )
+    except OSError:
+        pass
 
     label, zone_label = _get_label(always_tolerant=always_tolerant)
     if zone_name:


### PR DESCRIPTION
Fixes #526 