### PR TITLE
Housekeeping: De-cluttered UI and removed deprecated access to ChoiceSets

### DIFF
--- a/netbox_dns/models/__init__.py
+++ b/netbox_dns/models/__init__.py
@@ -6,8 +6,3 @@ from .registration_contact import *
 from .registrar import *
 from .zone_template import *
 from .record_template import *
-
-# +
-# Backwards compatibility fix, will be removed in version 1.1
-# -
-from netbox_dns.choices import *

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -23,6 +23,7 @@
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
+                    {% if object.tenant %}
                     <tr>
                         <th scope="row">{% trans "Tenant" %}</th>
                         <td>
@@ -32,6 +33,7 @@
                             {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
+                    {% endif %}
                 </table>
             </div>
             {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -63,17 +63,6 @@
                     <td><a href="{% url 'plugins:netbox_dns:zone_records' pk=object.zone.pk %}">{{ object.zone }}</a></td>
                     {% endif %}
                 </tr>
-                {% if not object.managed or object.tenant %}
-                <tr>
-                    <th scope="row">{% trans "Tenant" %}</th>
-                    <td>
-                        {% if object.tenant.group %}
-                            {{ object.tenant.group|linkify }} /
-                        {% endif %}
-                        {{ object.tenant|linkify|placeholder }}
-                    </td>
-                </tr>
-                {% endif %}
                 <tr>
                     <th scope="row">{% trans "Type" %}</th>
                     <td>{{ object.type }}</td>
@@ -82,16 +71,33 @@
                     <th scope="row">{% trans "Value" %}</th>
                     <td style="word-break:break-all;">{{ object.value }}</td>
                 </tr>
+                {% if unicode_value %}
+                <tr>
+                    <th scope="row">{% trans "Unicode Value" %}</th>
+                    <td style="word-break:break-all;">{{ unicode_value }}</td>
+                </tr>
+                {% endif %}
                 {% if cname_warning %}
                 <tr class="text-warning">
                     <th scope="row">{% trans "Warning" %}</th>
                     <td>{{ cname_warning }}</td>
                 </tr>
                 {% endif %}
-                {% if unicode_value %}
+                {% if object.description %}
                 <tr>
-                    <th scope="row">{% trans "Unicode Value" %}</th>
-                    <td style="word-break:break-all;">{{ unicode_value }}</td>
+                    <th scope="row">{% trans "Description" %}</th>
+                    <td style="word-break:break-all;">{{ object.description }}</td>
+                </tr>
+                {% endif %}
+                {% if object.tenant %}
+                <tr>
+                    <th scope="row">{% trans "Tenant" %}</th>
+                    <td>
+                        {% if object.tenant.group %}
+                            {{ object.tenant.group|linkify }} /
+                        {% endif %}
+                        {{ object.tenant|linkify|placeholder }}
+                    </td>
                 </tr>
                 {% endif %}
                 <tr>
@@ -132,12 +138,6 @@
                     <th scope="row">Status</th>
                     <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                 </tr>
-                {% if object.description %}
-                <tr>
-                    <th scope="row">{% trans "Description" %}</th>
-                    <td style="word-break:break-all;">{{ object.description }}</td>
-                </tr>
-                {% endif %}
             </table>
         </div>
         {% if cname_target_table %}

--- a/netbox_dns/templates/netbox_dns/recordtemplate.html
+++ b/netbox_dns/templates/netbox_dns/recordtemplate.html
@@ -25,6 +25,12 @@
                     <td style="word-break:break-all;">{{ unicode_name }}</td>
                 </tr>
                 {% endif %}
+                {% if object.description %}
+                <tr>
+                    <th scope="row">{% trans "Description" %}</th>
+                    <td style="word-break:break-all;">{{ object.description }}</td>
+                </tr>
+                {% endif %}
                 {% if object.tenant %}
                 <tr>
                     <th scope="row">{% trans "Tenant" %}</th>
@@ -64,12 +70,6 @@
                     <th scope="row">{% trans "Status" %}</th>
                     <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
                 </tr>
-                {% if object.description %}
-                <tr>
-                    <th scope="row">{% trans "Description" %}</th>
-                    <td style="word-break:break-all;">{{ object.description }}</td>
-                </tr>
-                {% endif %}
             </table>
         </div>
         {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_dns/templates/netbox_dns/view.html
+++ b/netbox_dns/templates/netbox_dns/view.html
@@ -21,6 +21,7 @@
                         <td style="word-break:break-all;">{{ object.description }}</td>
                     </tr>
                     {% endif %}
+                    {% if object.tenant %}
                     <tr>
                         <th scope="row">{% trans "Tenant" %}</th>
                         <td>
@@ -30,6 +31,7 @@
                             {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
+                    {% endif %}
                 </table>
             </div>
             {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -36,6 +36,7 @@
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
+                {% if object.tenant %}
                 <tr>
                     <th scope="row">{% trans "Tenant" %}</th>
                     <td>
@@ -45,6 +46,7 @@
                         {{ object.tenant|linkify|placeholder }}
                     </td>
                 </tr>
+                {% endif %}
                 <tr>
                     <th scope="row">{% trans "Status" %}</th>
                     <td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
@@ -90,10 +92,6 @@
                 <tr>
                     <th scope="row">{% trans "Default TTL" %}</th>
                     <td>{{ object.default_ttl }}</td>
-                </tr>
-                <tr>
-                    <th scope="row">{% trans "Description" %}</th>
-                    <td>{{ object.description }}</td>
                 </tr>
             </table>
         </div>

--- a/netbox_dns/templates/netbox_dns/zonetemplate.html
+++ b/netbox_dns/templates/netbox_dns/zonetemplate.html
@@ -21,6 +21,7 @@
                     <td style="word-break:break-all;">{{ object.description }}</td>
                 </tr>
                 {% endif %}
+                {% if object.tenant %}
                 <tr>
                     <th scope="row">{% trans "Tenant" %}</th>
                     <td>
@@ -30,6 +31,7 @@
                         {{ object.tenant|linkify|placeholder }}
                     </td>
                 </tr>
+                {% endif %}
                 <tr>
                     <th scope="row">{% trans "Nameservers" %}</th>
                     <td>
@@ -39,10 +41,6 @@
                             {% endfor %}
                         </table>
                     </td>
-                </tr>
-                <tr>
-                    <th scope="row">{% trans "Description" %}</th>
-                    <td>{{ object.description }}</td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
This PR contains various cleanups:

* Duplicated "Description" field in `Zone` and `ZoneTemplate` detail views removed
* Rearranged the order of some fields in `Record` detail view to be more logical
* Uniformly only display "Tenant" in detail views when it's actually used (this was only be done for some, not all)

In addition, the deprecated access to `models.Record*Choices` and `models.Zone*Choices` has now been removed. It was deprecated for a while now and originally was scheduled for removal in version 1.1.