### PR TITLE
Added FilterSets to all BulkDelete views

### DIFF
--- a/netbox_dns/views/nameserver.py
+++ b/netbox_dns/views/nameserver.py
@@ -83,6 +83,7 @@ class NameServerBulkEditView(generic.BulkEditView):
 @register_model_view(NameServer, "bulk_delete", path="delete", detail=False)
 class NameServerBulkDeleteView(generic.BulkDeleteView):
     queryset = NameServer.objects.all()
+    filterset = NameServerFilterSet
     table = NameServerTable
 
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -198,6 +198,7 @@ class RecordBulkEditView(generic.BulkEditView):
 @register_model_view(Record, "bulk_delete", path="delete", detail=False)
 class RecordBulkDeleteView(generic.BulkDeleteView):
     queryset = Record.objects.filter(managed=False)
+    filterset = RecordFilterSet
     table = RecordTable
 
 

--- a/netbox_dns/views/record_template.py
+++ b/netbox_dns/views/record_template.py
@@ -90,4 +90,5 @@ class RecordTemplateBulkEditView(generic.BulkEditView):
 @register_model_view(RecordTemplate, "bulk_delete", path="delete", detail=False)
 class RecordTemplateBulkDeleteView(generic.BulkDeleteView):
     queryset = RecordTemplate.objects.all()
+    filterset = RecordTemplateFilterSet
     table = RecordTemplateTable

--- a/netbox_dns/views/registrar.py
+++ b/netbox_dns/views/registrar.py
@@ -72,6 +72,7 @@ class RegistrarBulkEditView(generic.BulkEditView):
 @register_model_view(Registrar, "bulk_delete", path="delete", detail=False)
 class RegistrarBulkDeleteView(generic.BulkDeleteView):
     queryset = Registrar.objects.all()
+    filterset = RegistrarFilterSet
     table = RegistrarTable
 
 

--- a/netbox_dns/views/registration_contact.py
+++ b/netbox_dns/views/registration_contact.py
@@ -73,6 +73,7 @@ class RegistrationContactBulkEditView(generic.BulkEditView):
 @register_model_view(RegistrationContact, "bulk_delete", path="delete", detail=False)
 class RegistrationContactBulkDeleteView(generic.BulkDeleteView):
     queryset = RegistrationContact.objects.all()
+    filterset = RegistrationContactFilterSet
     table = RegistrationContactTable
 
 

--- a/netbox_dns/views/view.py
+++ b/netbox_dns/views/view.py
@@ -76,6 +76,7 @@ class ViewBulkEditView(generic.BulkEditView):
 @register_model_view(View, "bulk_delete", path="delete", detail=False)
 class ViewBulkDeleteView(generic.BulkDeleteView):
     queryset = View.objects.all()
+    filterset = ViewFilterSet
     table = ViewTable
 
 

--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -101,6 +101,7 @@ class ZoneBulkEditView(generic.BulkEditView):
 @register_model_view(Zone, "bulk_delete", path="delete", detail=False)
 class ZoneBulkDeleteView(generic.BulkDeleteView):
     queryset = Zone.objects.all()
+    filterset = ZoneFilterSet
     table = ZoneTable
 
 

--- a/netbox_dns/views/zone_template.py
+++ b/netbox_dns/views/zone_template.py
@@ -80,4 +80,5 @@ class ZoneTemplateBulkEditView(generic.BulkEditView):
 @register_model_view(ZoneTemplate, "bulk_delete", path="delete", detail=False)
 class ZoneTemplateBulkDeleteView(generic.BulkDeleteView):
     queryset = ZoneTemplate.objects.all()
+    filterset = ZoneTemplateFilterSet
     table = ZoneTemplateTable


### PR DESCRIPTION
fixes #531 

The `filterset` definition was missing with all `*BulkDeleteView` classes, leading to filters being ignored when the 'Delete all xxx matching yyy' option was used.