### PR TITLE
Normalise name server, zone and record names to lowercase

### DIFF
--- a/netbox_dns/models/nameserver.py
+++ b/netbox_dns/models/nameserver.py
@@ -73,6 +73,11 @@ class NameServer(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:netbox_dns:nameserver", kwargs={"pk": self.pk})
 
+    def clean_fields(self, exclude=None):
+        self.name = self.name.lower()
+
+        super().clean_fields(exclude=exclude)
+
     def clean(self, *args, **kwargs):
         try:
             self.name = normalize_name(self.name)

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -371,9 +371,11 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         if ptr_zone.is_rfc2317_zone:
             ptr_name = self.rfc2317_ptr_name
         else:
-            ptr_name = dns_name.from_text(
-                ipaddress.ip_address(self.value).reverse_pointer
-            ).relativize(dns_name.from_text(ptr_zone.name)).to_text()
+            ptr_name = (
+                dns_name.from_text(ipaddress.ip_address(self.value).reverse_pointer)
+                .relativize(dns_name.from_text(ptr_zone.name))
+                .to_text()
+            )
 
         ptr_value = self.fqdn
         ptr_record = self.ptr_record
@@ -440,9 +442,13 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
     def update_rfc2317_cname_record(self, save_zone_serial=True):
         if self.zone.rfc2317_parent_managed:
-            cname_name = dns_name.from_text(
-                ipaddress.ip_address(self.ip_address).reverse_pointer
-            ).relativize(dns_name.from_text(self.zone.rfc2317_parent_zone.name)).to_text()
+            cname_name = (
+                dns_name.from_text(
+                    ipaddress.ip_address(self.ip_address).reverse_pointer
+                )
+                .relativize(dns_name.from_text(self.zone.rfc2317_parent_zone.name))
+                .to_text()
+            )
 
             if self.rfc2317_cname_record is not None:
                 if self.rfc2317_cname_record.name == cname_name:

--- a/netbox_dns/models/record_template.py
+++ b/netbox_dns/models/record_template.py
@@ -174,9 +174,11 @@ class RecordTemplate(NetBoxModel):
         if tags := self.tags.all():
             record.tags.set(tags)
 
-    def clean_fields(self, *args, **kwargs):
+    def clean_fields(self, exclude=None):
         self.type = self.type.upper()
-        super().clean_fields(*args, **kwargs)
+        self.record_name = self.record_name.lower()
+
+        super().clean_fields(exclude=exclude)
 
     def clean(self, *args, **kwargs):
         self.validate_name()

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -663,6 +663,8 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
     def clean_fields(self, exclude=None):
         defaults = settings.PLUGINS_CONFIG.get("netbox_dns")
 
+        self.name = self.name.lower()
+
         if self.view_id is None:
             self.view_id = View.get_default_view().pk
 

--- a/netbox_dns/tests/nameserver/test_name_validation.py
+++ b/netbox_dns/tests/nameserver/test_name_validation.py
@@ -37,6 +37,17 @@ class NameServerNameValidationTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 NameServer.objects.create(name=name)
 
+    def test_name_lowercase(self):
+        nameserver = NameServer.objects.create(name="NS1.example.COM")
+
+        self.assertEqual(nameserver.name, "ns1.example.com")
+
+    def test_name_case_insensitive_conflict(self):
+        NameServer.objects.create(name="ns1.example.com")
+
+        with self.assertRaises(ValidationError):
+            NameServer.objects.create(name="NS1.example.COM")
+
     @override_settings(
         PLUGINS_CONFIG={"netbox_dns": {"tolerate_underscores_in_labels": True}}
     )

--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -124,6 +124,19 @@ class RecordNameValidationTestCase(TestCase):
                     name=record.get("name"), zone=record.get("zone"), **self.record_data
                 )
 
+    def test_name_lowercase(self):
+        record = Record.objects.create(
+            name="NAME1", zone=self.zones[0], **self.record_data
+        )
+
+        self.assertEqual(record.fqdn, "name1.zone1.example.com.")
+
+    def test_name_case_insensitive_conflict(self):
+        Record.objects.create(name="name1", zone=self.zones[0], **self.record_data)
+
+        with self.assertRaises(ValidationError):
+            Record.objects.create(name="NAME1", zone=self.zones[0], **self.record_data)
+
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {

--- a/netbox_dns/tests/record/test_name_validation.py
+++ b/netbox_dns/tests/record/test_name_validation.py
@@ -52,8 +52,8 @@ class RecordNameValidationTestCase(TestCase):
             {"name": "x" * 63 + f".{self.zones[1].name}", "zone": self.zones[1]},
             {"name": "xn--nme1-loa", "zone": self.zones[0]},
             {"name": "xn--nme2-loa.zone1.example.com.", "zone": self.zones[0]},
-            {"name": "XN--nme1-loa", "zone": self.zones[0]},
-            {"name": "XN--nme2-loa.zone1.example.com.", "zone": self.zones[0]},
+            {"name": "XN--nme3-loa", "zone": self.zones[0]},
+            {"name": "XN--nme4-loa.zone1.example.com.", "zone": self.zones[0]},
         )
 
         for record in records:

--- a/netbox_dns/tests/zone/test_name_validation.py
+++ b/netbox_dns/tests/zone/test_name_validation.py
@@ -61,6 +61,17 @@ class ZoneNameValidationTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 Zone.objects.create(name=name, **self.zone_data)
 
+    def test_name_lowercase(self):
+        zone = Zone.objects.create(name="ZONE1.example.COM", **self.zone_data)
+
+        self.assertEqual(zone.name, "zone1.example.com")
+
+    def test_name_case_insensitive_conflict(self):
+        Zone.objects.create(name="zone1.example.com", **self.zone_data)
+
+        with self.assertRaises(ValidationError):
+            Zone.objects.create(name="ZONE1.example.COM", **self.zone_data)
+
     @override_settings(
         PLUGINS_CONFIG={
             "netbox_dns": {


### PR DESCRIPTION
fixes #547 

This change has been long overdue, thanks to @john2893 for pointing out the problem in #546.

With this change in place, all record, nameserver and zone names will be normalised to all-lowercase letters. This solves the problem described in #546 and the resulting issue, as well as several other potential uniqueness problems with names that may arise from case-sensitive comparisons.

Breaking change: All objects of the classes mentioned above will be modified so their names use lower case letters only on next save.