### PR TITLE
Added new error messages to the migrations for ci uniqueness of Nameserver and Zone

### DIFF
--- a/netbox_dns/migrations/0014_alter_unique_constraints_lowercase.py
+++ b/netbox_dns/migrations/0014_alter_unique_constraints_lowercase.py
@@ -25,7 +25,9 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="nameserver",
             constraint=models.UniqueConstraint(
-                django.db.models.functions.text.Lower("name"), name="name_unique_ci"
+                django.db.models.functions.text.Lower("name"),
+                name="name_unique_ci",
+                violation_error_message="There is already a nameserver with this name",
             ),
         ),
         migrations.AddConstraint(
@@ -34,6 +36,7 @@ class Migration(migrations.Migration):
                 django.db.models.functions.text.Lower("name"),
                 models.F("view"),
                 name="name_view_unique_ci",
+                violation_error_message="There is already a zone with the same name in this view",
             ),
         ),
     ]


### PR DESCRIPTION
The error messages added recently were still missing from the migrations.