### PR TITLE
Added a TimePeriod field for ISO 8601 duration entry

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -145,6 +145,10 @@ NetBox 3.5.0 up to NetBox 3.7.x are not supported by the latest version of NetBo
 ## Object types
 Currently NetBox DNS can manage eight different object types: Views, Name Servers, Zone Templates, Zones, Record Templates, Records, Registration Contacts and Registrars.
 
+For all fields that contain time periods (record TTL and the zone SOA timer fields, just to name a few) there is an alternative way of entering values. Instead of having to convert the desired value to seconds, NetBox DNS supports a subset of the ISO 8601 duration format starting with version 1.2.6. To specify a TTL of one day, the format "P1D" is accepted, which will be converted to 86400 before being written to the database. A time period of 15 hours is written as "PT15H" (the "T" means that the remaining part of the string represents time, not date) is interpreted as 54000. All letters have to be uppercase.
+
+Please note that the ISO 8601 support is not complete. For example, "P4W" won't work as the only non-time-related unit supported is "D". This is a restriction of the `django.dateutil` module and will be resolved automatically if and when full ISO 8601 duration support is implemented by the Django project.
+
 ### Views
 Views are a concept that allows the DNS name space to be partitioned into groups of zones that are isolated from each other. They are mainly used in split horizon DNS setups, for example in cases where there is a different DNS resolution requirement for external and internal clients, where external clients do not get the same set of names, or see different IP addresses than internal clients in case of NAT setups. Other scenarios are possible as well.
 

--- a/netbox_dns/fields/__init__.py
+++ b/netbox_dns/fields/__init__.py
@@ -2,3 +2,4 @@ from .network import *
 from .address import *
 from .rfc2317 import *
 from .ipam import *
+from .timeperiod import *

--- a/netbox_dns/fields/timeperiod.py
+++ b/netbox_dns/fields/timeperiod.py
@@ -1,0 +1,31 @@
+from django.forms import Field
+from django.utils.dateparse import parse_duration
+from django.core.exceptions import ValidationError
+
+
+__all__ = ("TimePeriodField",)
+
+
+class TimePeriodField(Field):
+    def to_python(self, value):
+        if not value:
+            return None
+
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                duration = parse_duration(value)
+                if duration is None:
+                    raise TypeError
+                return int(duration.total_seconds())
+            except TypeError:
+                raise ValidationError(
+                    "Enter a valid integer or ISO 8601 duration (W, M and Y are not supported)"
+                )
+
+    def validate(self, value):
+        super().validate(value)
+
+        if value is not None and value < 0:
+            raise ValidationError("A time period cannot be negative.")

--- a/netbox_dns/forms/record.py
+++ b/netbox_dns/forms/record.py
@@ -23,6 +23,7 @@ from tenancy.forms import TenancyForm, TenancyFilterForm
 from netbox_dns.models import View, Zone, Record
 from netbox_dns.choices import RecordSelectableTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode
+from netbox_dns.fields import TimePeriodField
 
 
 __all__ = (
@@ -67,7 +68,7 @@ class RecordForm(TenancyForm, NetBoxModelForm):
         required=False,
         label=_("Disable PTR"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )
@@ -112,16 +113,17 @@ class RecordFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     fieldsets = (
         FieldSet("q", "filter_id", "tag"),
         FieldSet(
+            "name",
             "view_id",
             "zone_id",
-            "name",
             "fqdn",
             "type",
             "value",
-            "disable_ptr",
             "status",
-            "active",
+            "ttl",
+            "disable_ptr",
             "description",
+            "active",
             name=_("Attributes"),
         ),
         FieldSet("tenant_group_id", "tenant_id", name=_("Tenancy")),
@@ -153,6 +155,10 @@ class RecordFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         choices=RecordStatusChoices,
         required=False,
         label=_("Status"),
+    )
+    ttl = TimePeriodField(
+        required=False,
+        label=_("TTL"),
     )
     view_id = DynamicModelMultipleChoiceField(
         queryset=View.objects.all(),
@@ -224,7 +230,7 @@ class RecordImportForm(NetBoxModelImportForm):
         required=False,
         label=_("Status"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )
@@ -286,7 +292,7 @@ class RecordBulkEditForm(NetBoxModelBulkEditForm):
         required=False,
         label=_("Status"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )

--- a/netbox_dns/forms/record_template.py
+++ b/netbox_dns/forms/record_template.py
@@ -23,6 +23,7 @@ from tenancy.forms import TenancyForm, TenancyFilterForm
 from netbox_dns.models import RecordTemplate, ZoneTemplate
 from netbox_dns.choices import RecordSelectableTypeChoices, RecordStatusChoices
 from netbox_dns.utilities import name_to_unicode
+from netbox_dns.fields import TimePeriodField
 
 
 __all__ = (
@@ -50,7 +51,7 @@ class RecordTemplateForm(TenancyForm, NetBoxModelForm):
         required=False,
         label=_("Disable PTR"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )
@@ -99,6 +100,7 @@ class RecordTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
             "type",
             "value",
             "status",
+            "ttl",
             "disable_ptr",
             "description",
             name=_("Attributes"),
@@ -129,6 +131,10 @@ class RecordTemplateFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         required=False,
         label=_("Status"),
     )
+    ttl = TimePeriodField(
+        required=False,
+        label=_("TTL"),
+    )
     disable_ptr = forms.NullBooleanField(
         required=False,
         label=_("Disable PTR"),
@@ -156,7 +162,7 @@ class RecordTemplateImportForm(NetBoxModelImportForm):
         required=False,
         label=_("Status"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )
@@ -209,7 +215,7 @@ class RecordTemplateBulkEditForm(NetBoxModelBulkEditForm):
         required=False,
         label=_("Status"),
     )
-    ttl = forms.IntegerField(
+    ttl = TimePeriodField(
         required=False,
         label=_("TTL"),
     )

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -39,7 +39,7 @@ from netbox_dns.models import (
 )
 from netbox_dns.choices import ZoneStatusChoices
 from netbox_dns.utilities import name_to_unicode, network_to_reverse
-from netbox_dns.fields import RFC2317NetworkFormField
+from netbox_dns.fields import RFC2317NetworkFormField, TimePeriodField
 from netbox_dns.validators import validate_ipv4, validate_prefix, validate_rfc2317
 
 
@@ -171,7 +171,7 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
         label=_("Nameservers"),
         quick_add=QUICK_ADD,
     )
-    default_ttl = forms.IntegerField(
+    default_ttl = TimePeriodField(
         required=False,
         help_text=_("Default TTL for new records in this zone"),
         validators=[MinValueValidator(1)],
@@ -181,7 +181,7 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
         required=False,
         label=_("Description"),
     )
-    soa_ttl = forms.IntegerField(
+    soa_ttl = TimePeriodField(
         required=True,
         help_text=_("TTL for the SOA record of the zone"),
         validators=[MinValueValidator(1)],
@@ -199,25 +199,25 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
         help_text=_("Mailbox of the zone's administrator"),
         label=_("SOA RName"),
     )
-    soa_refresh = forms.IntegerField(
+    soa_refresh = TimePeriodField(
         required=True,
         help_text=_("Refresh interval for secondary nameservers"),
         validators=[MinValueValidator(1)],
         label=_("SOA Refresh"),
     )
-    soa_retry = forms.IntegerField(
+    soa_retry = TimePeriodField(
         required=True,
         help_text=_("Retry interval for secondary nameservers"),
         validators=[MinValueValidator(1)],
         label=_("SOA Retry"),
     )
-    soa_expire = forms.IntegerField(
+    soa_expire = TimePeriodField(
         required=True,
         validators=[MinValueValidator(1)],
         help_text=_("Expire time after which the zone is considered unavailable"),
         label=_("SOA Expire"),
     )
-    soa_minimum = forms.IntegerField(
+    soa_minimum = TimePeriodField(
         required=True,
         help_text=_("Minimum TTL for negative results, e.g. NXRRSET, NXDOMAIN"),
         validators=[MinValueValidator(1)],
@@ -530,11 +530,11 @@ class ZoneImportForm(ZoneTemplateUpdateMixin, NetBoxModelImportForm):
         required=False,
         label=_("Nameservers"),
     )
-    default_ttl = forms.IntegerField(
+    default_ttl = TimePeriodField(
         required=False,
         label=_("Default TTL"),
     )
-    soa_ttl = forms.IntegerField(
+    soa_ttl = TimePeriodField(
         required=False,
         help_text=_("TTL for the SOA record of the zone"),
         label=_("SOA TTL"),
@@ -562,22 +562,22 @@ class ZoneImportForm(ZoneTemplateUpdateMixin, NetBoxModelImportForm):
         required=False,
         label=_("SOA Serial"),
     )
-    soa_refresh = forms.IntegerField(
+    soa_refresh = TimePeriodField(
         required=False,
         help_text=_("Refresh interval for secondary nameservers"),
         label=_("SOA Refresh"),
     )
-    soa_retry = forms.IntegerField(
+    soa_retry = TimePeriodField(
         required=False,
         help_text=_("Retry interval for secondary nameservers"),
         label=_("SOA Retry"),
     )
-    soa_expire = forms.IntegerField(
+    soa_expire = TimePeriodField(
         required=False,
         help_text=_("Expire time after which the zone is considered unavailable"),
         label=_("SOA Expire"),
     )
-    soa_minimum = forms.IntegerField(
+    soa_minimum = TimePeriodField(
         required=False,
         help_text=_("Minimum TTL for negative results, e.g. NXRRSET, NXDOMAIN"),
         label=_("SOA Minimum TTL"),
@@ -726,7 +726,7 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
         required=False,
         label=_("Nameservers"),
     )
-    default_ttl = forms.IntegerField(
+    default_ttl = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("Default TTL"),
@@ -736,7 +736,7 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
         required=False,
         label=_("Description"),
     )
-    soa_ttl = forms.IntegerField(
+    soa_ttl = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("SOA TTL"),
@@ -760,22 +760,22 @@ class ZoneBulkEditForm(NetBoxModelBulkEditForm):
         validators=[MinValueValidator(1), MaxValueValidator(4294967295)],
         label=_("SOA Serial"),
     )
-    soa_refresh = forms.IntegerField(
+    soa_refresh = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("SOA Refresh"),
     )
-    soa_retry = forms.IntegerField(
+    soa_retry = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("SOA Retry"),
     )
-    soa_expire = forms.IntegerField(
+    soa_expire = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("SOA Expire"),
     )
-    soa_minimum = forms.IntegerField(
+    soa_minimum = TimePeriodField(
         required=False,
         validators=[MinValueValidator(1)],
         label=_("SOA Minimum TTL"),


### PR DESCRIPTION
Django has (limited) support for ISO 8601 duration values. This PR makes use of what is available to ease the entry of time periods, e.g. for SOA fields. Instead of entering a value like "8640000", it's now possible to enter "P100D" for "100 days".

It should be noted that Django does not support ISO 8601 durations in their entirety. There are other Python libraries that do, but it didn't seem justified to add a new dependency just for a little simplification in the input forms.