### PR TITLE
Check whether zone was passed via dict before resolving templates

### DIFF
--- a/netbox_dns/api/serializers_/zone.py
+++ b/netbox_dns/api/serializers_/zone.py
@@ -119,7 +119,7 @@ class ZoneSerializer(NetBoxModelSerializer):
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
 
     def validate(self, data):
-        if (template := data.get("template")) is not None:
+        if isinstance(data, dict) and (template := data.get("template")) is not None:
             template.apply_to_zone_data(data)
 
         return super().validate(data)


### PR DESCRIPTION
This PR resolves an issue with the way NetBox resolves custom field references in the API.

When referencing an object in a custom field, NetBox apparently passes an object reference instead of a deserialised object in a `dict` to the serialiser. This causes the templating mechanism to fail with an `AttributeError`.

fixes #593.