### PR TITLE
Add tests for NetBox DNS objects as custom field targets

### DIFF
--- a/netbox_dns/tests/custom.py
+++ b/netbox_dns/tests/custom.py
@@ -5,15 +5,9 @@ import strawberry_django
 from django.urls import reverse
 from django.utils.module_loading import import_string
 
-try:
-    from strawberry.types.base import StrawberryList, StrawberryOptional
-    from strawberry.types.union import StrawberryUnion
-    from strawberry.types.lazy_type import LazyType
-except ImportError:
-    from strawberry.type import StrawberryList, StrawberryOptional
-    from strawberry.union import StrawberryUnion
-    from strawberry.lazy_type import LazyType
-
+from strawberry.types.base import StrawberryList, StrawberryOptional
+from strawberry.types.union import StrawberryUnion
+from strawberry.types.lazy_type import LazyType
 
 from ipam.graphql.types import IPAddressFamilyType
 from utilities.testing.api import APITestCase as NetBoxAPITestCase

--- a/netbox_dns/tests/custom/__init__.py
+++ b/netbox_dns/tests/custom/__init__.py
@@ -1,0 +1,2 @@
+from .netbox import *
+from .netbox_dns import *

--- a/netbox_dns/tests/custom/netbox.py
+++ b/netbox_dns/tests/custom/netbox.py
@@ -15,6 +15,13 @@ from utilities.testing.views import ModelViewTestCase as NetBoxModelViewTestCase
 from netbox.api.exceptions import GraphQLTypeNotFound
 
 
+__all__ = (
+    "NetBoxDNSGraphQLMixin",
+    "ModelViewTestCase",
+    "APITestCase",
+)
+
+
 def get_graphql_type_for_model(model):
     app_label, model_name = model._meta.label.split(".")
     class_name = f"{app_label}.graphql.types.NetBoxDNS{model_name}Type"

--- a/netbox_dns/tests/custom/netbox_dns.py
+++ b/netbox_dns/tests/custom/netbox_dns.py
@@ -1,0 +1,43 @@
+from django.urls import reverse
+from rest_framework import status
+
+from core.models import ObjectType
+from extras.choices import CustomFieldTypeChoices
+from extras.models import CustomField
+from ipam.models import IPAddress
+
+
+__all__ = ("CustomFieldTargetAPIMixin",)
+
+
+class CustomFieldTargetAPIMixin:
+    def test_custom_field_target(self):
+        self.add_permissions(
+            "ipam.change_ipaddress",
+        )
+
+        ip_address = IPAddress.objects.create(
+            address="2001:db8::dead:beef/48",
+        )
+
+        cf = CustomField.objects.create(
+            name="object_field",
+            type=CustomFieldTypeChoices.TYPE_OBJECT,
+            related_object_type=ObjectType.objects.get_for_model(self.model),
+            required=False,
+        )
+        cf.object_types.set([ObjectType.objects.get_for_model(IPAddress)])
+
+        instance = self.model.objects.first()
+
+        url = reverse("ipam-api:ipaddress-detail", kwargs={"pk": ip_address.pk})
+        data = {
+            "custom_fields": {
+                cf.name: instance.pk,
+            },
+        }
+        response = self.client.patch(url, data, format="json", **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        ip_address.refresh_from_db()
+        self.assertEqual(ip_address.custom_field_data[cf.name], instance.pk)

--- a/netbox_dns/tests/dnssec_key_template/test_api.py
+++ b/netbox_dns/tests/dnssec_key_template/test_api.py
@@ -3,7 +3,11 @@ from rest_framework import status
 
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import DNSSECKeyTemplate
 from netbox_dns.choices import (
     DNSSECKeyTemplateTypeChoices,
@@ -20,6 +24,7 @@ class DNSSECKeyTemplateAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = DNSSECKeyTemplate

--- a/netbox_dns/tests/dnssec_policy/test_api.py
+++ b/netbox_dns/tests/dnssec_policy/test_api.py
@@ -3,7 +3,11 @@ from rest_framework import status
 
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import DNSSECPolicy, DNSSECKeyTemplate
 from netbox_dns.choices import (
     DNSSECPolicyDigestChoices,
@@ -21,6 +25,7 @@ class DNSSECPolicyAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = DNSSECPolicy

--- a/netbox_dns/tests/nameserver/test_api.py
+++ b/netbox_dns/tests/nameserver/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import NameServer
 
 
@@ -12,6 +16,7 @@ class NameServerAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = NameServer

--- a/netbox_dns/tests/record/test_api.py
+++ b/netbox_dns/tests/record/test_api.py
@@ -4,7 +4,11 @@ from rest_framework import status
 
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import View, Zone, NameServer, Record
 from netbox_dns.choices import RecordTypeChoices
 
@@ -17,6 +21,7 @@ class RecordAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = Record

--- a/netbox_dns/tests/record_template/test_api.py
+++ b/netbox_dns/tests/record_template/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases, create_tags
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import RecordTemplate
 from netbox_dns.choices import RecordTypeChoices
 
@@ -13,6 +17,7 @@ class RecordTemplateAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = RecordTemplate

--- a/netbox_dns/tests/registrar/test_api.py
+++ b/netbox_dns/tests/registrar/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import Registrar
 
 
@@ -12,6 +16,7 @@ class RegistrarAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = Registrar

--- a/netbox_dns/tests/registration_contact/test_api.py
+++ b/netbox_dns/tests/registration_contact/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import RegistrationContact
 
 
@@ -12,6 +16,7 @@ class RegistrationContactAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = RegistrationContact

--- a/netbox_dns/tests/view/test_api.py
+++ b/netbox_dns/tests/view/test_api.py
@@ -2,8 +2,13 @@ from django.test import override_settings
 from rest_framework import status
 
 from utilities.testing import APIViewTestCases
+from ipam.models import IPAddress
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import View
 
 
@@ -15,6 +20,7 @@ class ViewAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = View

--- a/netbox_dns/tests/zone/test_api.py
+++ b/netbox_dns/tests/zone/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases, create_tags
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import View, Zone, NameServer, Registrar, RegistrationContact
 from netbox_dns.choices import ZoneStatusChoices, ZoneEPPStatusChoices
 
@@ -13,6 +17,7 @@ class ZoneAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = Zone

--- a/netbox_dns/tests/zone_template/test_api.py
+++ b/netbox_dns/tests/zone_template/test_api.py
@@ -1,6 +1,10 @@
 from utilities.testing import APIViewTestCases, create_tags
 
-from netbox_dns.tests.custom import APITestCase, NetBoxDNSGraphQLMixin
+from netbox_dns.tests.custom import (
+    APITestCase,
+    NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
+)
 from netbox_dns.models import (
     ZoneTemplate,
     RecordTemplate,
@@ -19,6 +23,7 @@ class ZoneTemplateAPITestCase(
     APIViewTestCases.UpdateObjectViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
     NetBoxDNSGraphQLMixin,
+    CustomFieldTargetAPIMixin,
     APIViewTestCases.GraphQLTestCase,
 ):
     model = ZoneTemplate


### PR DESCRIPTION
This PR adds a special test for using a NetBox DNS object as a target object in a custom field. The purpose is to catch errors like the one that caused issue #593.

Additionally some obsolete code for NetBox 4.0.x testing was removed.