### PR TITLE
Initialise views in `urls.py` instead of `ready()`

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -98,13 +98,6 @@ class DNSConfig(PluginConfig):
         ):
             _check_list(setting)
 
-        # +
-        # TODO: Remove this workaround as soon as it's no longer required
-        #
-        # Force loading views so the register_model_view is run for all views
-        # -
-        import netbox_dns.views  # noqa: F401
-
 
 #
 # Initialize plugin config

--- a/netbox_dns/urls.py
+++ b/netbox_dns/urls.py
@@ -2,6 +2,13 @@ from django.urls import include, path
 
 from utilities.urls import get_model_urls
 
+# +
+# Import views so the register_model_view is run. This is required for the
+# URLs to be set up properly with get_model_urls().
+# -
+from .views import *  # noqa: F401
+
+
 app_name = "netbox_dns"
 
 urlpatterns = (


### PR DESCRIPTION
fixes #582 

This PR removes an ugly workaround that was implemented so that the `register_model_view()` decorator was executed before using `get_model_urls()` in urls.py.

As it turned out this workaround has some side effects that cause some errors when NetBox is reloaded, among other things the aforementioned bug #582. Loading the views in `urls.py` instead solves those issues.