### PR TITLE
Redesigned the record ChoiceSets and created the `custom_record_types` option

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -419,7 +419,7 @@ For records the following fields are defined:
 Field           | Required | Explanation
 -----           | -------- | -----------
 **Zone**        | Yes      | The zone in which the record is to be defined
-**Type**        | Yes      | The type of the resource record. This can be one of a list of record types derived from [RFC 1035, Section 3.3](https://datatracker.ietf.org/doc/html/rfc1035#section-3.3), e.g. A or AAAA. The list of record types can be limited using the configuration variable `filter_record_types`.
+**Type**        | Yes      | The type of the resource record. This can be one of a list of record types derived from [RFC 1035, Section 3.3](https://datatracker.ietf.org/doc/html/rfc1035#section-3.3), e.g. A or AAAA. The list of record types can be limited using the configuration variable `filter_record_types`. Defining custom record types is possible as well using the configuration variable `custom_record_types`.
 **Disable PTR** | Yes      | A checkbox indicating whether a PTR record should be generated for an A or AAAA record automatically if there is a zone suitable for the PTR in NetBox DNS
 **Name**        | Yes      | The name of the record, e.g. the simple host name for A and AAAA records
 **Value**       | Yes      | The value of the record, e.g. the IPv4 or IPv6 addreess
@@ -807,8 +807,6 @@ The names of DNS Resource Records are subject to a number of RFCs, most notably 
 
 The names of Name Servers, Zones and Records are all used as RR names in DNS, so all of these are validated for conformity to the aforementioned RFCs. When a name does not comply with the RFC rules, NetBox DNS refuses to save the name server, zone or record with an error message indicating the reason for the refusal.
 
-**Please be aware that unlike names, values are not validated. While this is theoretically possible and may be implemented at some point, it is not a trivial task as there is a plethora of RR types with even more value formats.**
-
 ![Record Validation Error](images/RecordValidationError.png)
 
 ### Validation options
@@ -846,6 +844,13 @@ PLUGINS_CONFIG = {
     },
 }
 ```
+
+## Value validation
+Some limited amount of validation is applied to RR values as well. The validation rules are much less strict than for names because the targets for i.e. CNAME records may be records that are hosted by a different name server that applies different rules for name validation.
+
+The syntax of RR values is validated using `dnspython`, which provides basic syntax checking. This covers a lot of common errors in creating records.
+
+Please not that no validation at all - including length checks - is applied to custom record types allowed using the `custom_record_types` configuration variable.
 
 ## SOA SERIAL validation
 The SOA SERIAL field contains a serial number of a zone that is used to control if and when DNS secondary servers load zone updates from their primary servers. Basically, a secondary server checks for the SOA SERIAL of a zone on the primary server and only transfers the zone if that number is higher than the one it has in its own cached data. This does not depend on whether the transfer has been triggered by the upstream server via `NOTIFY` or whether it is scheduled by the secondary because the SOA REFRESH time has elapsed.

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -38,6 +38,7 @@ class DNSConfig(PluginConfig):
         ],
         "zone_expiration_warning_days": 30,
         "filter_record_types": [],
+        "custom_record_types": [],
         "record_active_status": [
             RecordStatusChoices.STATUS_ACTIVE,
         ],

--- a/netbox_dns/choices/dnssec_key_template.py
+++ b/netbox_dns/choices/dnssec_key_template.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from utilities.choices import ChoiceSet
 
-from .utilities import define_choice_attributes
+from .utilities import initialize_choice_names
 
 DEPRECATED_ALGORITHMS = (
     Algorithm.RSAMD5,
@@ -54,7 +54,7 @@ class DNSSECKeyTemplateKeySizeChoices(ChoiceSet):
     ]
 
 
-@define_choice_attributes()
+@initialize_choice_names
 class DNSSECKeyTemplateAlgorithmChoices(ChoiceSet):
     CHOICES = [
         (algorithm.name, f"{algorithm.name} ({algorithm.value})")

--- a/netbox_dns/choices/dnssec_policy.py
+++ b/netbox_dns/choices/dnssec_policy.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from utilities.choices import ChoiceSet
 
-from .utilities import define_choice_attributes
+from .utilities import initialize_choice_names
 
 DEPRECATED_DIGESTS = (
     DSDigest.NULL,
@@ -19,7 +19,7 @@ __all__ = (
 )
 
 
-@define_choice_attributes()
+@initialize_choice_names
 class DNSSECPolicyDigestChoices(ChoiceSet):
     CHOICES = [
         (digest.name, digest.name)

--- a/netbox_dns/choices/utilities.py
+++ b/netbox_dns/choices/utilities.py
@@ -1,26 +1,4 @@
-from django.core.exceptions import ImproperlyConfigured
-
-from netbox.plugins.utils import get_plugin_config
-
-
-def define_choice_attributes(filter_name=None):
-    try:
-        if filter_name is not None:
-            filter_choices = get_plugin_config("netbox_dns", filter_name, [])
-        else:
-            filter_choices = []
-    except ImproperlyConfigured:
-        filter_choices = []
-
-    def decorator(cls):
-        choices = []
-        for choice in cls._choices:
-            if choice[0] not in filter_choices:
-                setattr(cls, choice[0], choice[0])
-                choices.append(choice)
-        cls._choices = choices
-        cls.CHOICES = choices
-
-        return cls
-
-    return decorator
+def initialize_choice_names(cls):
+    for choice in cls.CHOICES:
+        setattr(cls, choice[0], choice[0])
+    return cls

--- a/netbox_dns/models/record.py
+++ b/netbox_dns/models/record.py
@@ -649,6 +649,9 @@ class Record(ObjectModificationMixin, ContactsMixin, NetBoxModel):
 
     @property
     def absolute_value(self):
+        if self.type in RecordTypeChoices.CUSTOM_TYPES:
+            return self.value
+
         zone = dns_name.from_text(self.zone.name)
         rr = rdata.from_text(RecordClassChoices.IN, self.type, self.value)
 

--- a/netbox_dns/validators/dns_value.py
+++ b/netbox_dns/validators/dns_value.py
@@ -52,6 +52,9 @@ def validate_record_value(record):
             for part in textwrap.wrap(raw_value, MAX_TXT_LENGTH, drop_whitespace=False)
         )
 
+    if record.type in (RecordTypeChoices.CUSTOM_TYPES):
+        return
+
     if record.type in (RecordTypeChoices.TXT, RecordTypeChoices.SPF):
         if not (record.value.isascii() and record.value.isprintable()):
             raise ValidationError(


### PR DESCRIPTION
fixes #598

This PR contains a redesign of the choicesets for the `Record` class. Apart from simplifying the setup of the dynamic choice sets and filtering record types it also makes it possible to create custom record types, such as `ALIAS` and `LUA`.

Custom record types will not be validated in any way.