### PR TITLE
Provide a default list of filtered RRTYPEs

### DIFF
--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -31,7 +31,47 @@ class DNSConfig(PluginConfig):
         "zone_soa_minimum": 3600,
         "zone_active_status": ["active", "dynamic"],
         "zone_expiration_warning_days": 30,
-        "filter_record_types": [],
+        "filter_record_types": [
+            # Obsolete or experimental RRTypes
+            "A6",  # RFC 6563: Historic
+            "AFSDB",  # RFC 5864: Obsolete
+            "APL",  # RFC 3123: Experimental
+            "AVC",  # https://www.iana.org/assignments/dns-parameters/AVC/avc-completed-template
+            "GPOS",  # RFC 1712: Experimental
+            "KEY",  # RFC 3755: Obsolete
+            "L32",  # RFC 6742: Experimental
+            "L64",  # RFC 6742: Experimental
+            "LP",  # RFC 6742: Experimental
+            "MB",  # RFC 2505: Unlikely to ever be adopted
+            "MD",  # RFC 973: Obsolete
+            "MF",  # RFC 973: Obsolete
+            "MG",  # RFC 2505: Unlikely to ever be adopted
+            "MINFO",  # RFC 2505: Unlikely to ever be adopted
+            "MR",  # RFC 2505: Unlikely to ever be adopted
+            "NID",  # RFC 6742: Experimental
+            "NINFO",  # Application expired
+            "NULL",  # RFC 1035: Obsolete
+            "NXT",  # RFC 3755: Obsolete
+            "SIG",  # RFC 3755: Obsolete
+            "SPF",  # RFC 7208: Obsolete
+            "WKS",  # RFC 1127: Not recommended
+            # RRTypes with no current use by any notable application
+            # (see https://en.wikipedia.org/wiki/List_of_DNS_record_types)
+            "RP",
+            "ISDN",
+            "RT",
+            "X25",
+            "NSAP",
+            "NSAP_PTR",
+            "PX",
+            "TYPE0",  # Reserved
+            "UNSPEC",  # Reserved
+            # DNSSEC RRTypes that are usually not manually maintained
+            "NSEC",
+            "NSEC3",
+            "RRSIG",
+        ],
+        "filter_record_types+": [],
         "custom_record_types": [],
         "record_active_status": ["active"],
         "dnssync_disabled": False,
@@ -84,6 +124,9 @@ class DNSConfig(PluginConfig):
             "record_active_status",
             "dnssync_ipaddress_active_status",
             "tolerate_leading_underscore_types",
+            "filter_record_types",
+            "filter_record_types+",
+            "custom_record_types",
         ):
             _check_list(setting)
 

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -3,9 +3,6 @@ from django.core.exceptions import ImproperlyConfigured
 
 from netbox.plugins import PluginConfig
 from netbox.plugins.utils import get_plugin_config
-from ipam.choices import IPAddressStatusChoices
-
-from netbox_dns.choices import RecordTypeChoices, RecordStatusChoices, ZoneStatusChoices
 
 __version__ = "1.2.7"
 
@@ -32,33 +29,24 @@ class DNSConfig(PluginConfig):
         "zone_soa_retry": 7200,
         "zone_soa_expire": 2419200,
         "zone_soa_minimum": 3600,
-        "zone_active_status": [
-            ZoneStatusChoices.STATUS_ACTIVE,
-            ZoneStatusChoices.STATUS_DYNAMIC,
-        ],
+        "zone_active_status": ["active", "dynamic"],
         "zone_expiration_warning_days": 30,
         "filter_record_types": [],
         "custom_record_types": [],
-        "record_active_status": [
-            RecordStatusChoices.STATUS_ACTIVE,
-        ],
+        "record_active_status": ["active"],
         "dnssync_disabled": False,
-        "dnssync_ipaddress_active_status": [
-            IPAddressStatusChoices.STATUS_ACTIVE,
-            IPAddressStatusChoices.STATUS_DHCP,
-            IPAddressStatusChoices.STATUS_SLAAC,
-        ],
+        "dnssync_ipaddress_active_status": ["active", "dhcp", "slaac"],
         "dnssync_conflict_deactivate": False,
         "dnssync_minimum_zone_labels": 2,
         "tolerate_characters_in_zone_labels": "",
         "tolerate_underscores_in_labels": False,
         "tolerate_leading_underscore_types": [
-            RecordTypeChoices.CNAME,
-            RecordTypeChoices.DNAME,
-            RecordTypeChoices.SRV,
-            RecordTypeChoices.SVCB,
-            RecordTypeChoices.TLSA,
-            RecordTypeChoices.TXT,
+            "CNAME",
+            "DNAME",
+            "SRV",
+            "SVCB",
+            "TLSA",
+            "TXT",
         ],
         "tolerate_non_rfc1035_types": [],
         "enable_root_zones": False,

--- a/netbox_dns/choices/record.py
+++ b/netbox_dns/choices/record.py
@@ -1,7 +1,6 @@
 from dns import rdatatype, rdataclass
 
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import ImproperlyConfigured
 
 from utilities.choices import ChoiceSet
 from netbox.plugins.utils import get_plugin_config
@@ -17,11 +16,8 @@ __all__ = (
 )
 
 
-def get_config_option(option_name):
-    try:
-        return get_plugin_config("netbox_dns", option_name, [])
-    except ImproperlyConfigured:
-        return []
+def _get_config_option(option_name):
+    return get_plugin_config("netbox_dns", option_name, [])
 
 
 class RecordTypeNames:
@@ -32,7 +28,7 @@ class RecordTypeNames:
                 for rdtype in rdatatype.RdataType
                 if not rdatatype.is_metatype(rdtype)
             ]
-            + get_config_option("custom_record_types")
+            + _get_config_option("custom_record_types")
         )
 
     def __iter__(self):
@@ -47,9 +43,9 @@ class RecordSelectableTypeNames:
                 rdtype.name
                 for rdtype in rdatatype.RdataType
                 if not rdatatype.is_metatype(rdtype)
-                and rdtype.name not in get_config_option("filter_record_types")
+                and rdtype.name not in _get_config_option("filter_record_types")
             ]
-            + get_config_option("custom_record_types")
+            + _get_config_option("custom_record_types")
         )
 
     def __iter__(self):
@@ -73,7 +69,7 @@ class RecordTypeChoices(ChoiceSet):
     SINGLETONS = [
         rdtype.name for rdtype in rdatatype.RdataType if rdatatype.is_singleton(rdtype)
     ]
-    CUSTOM_TYPES = get_config_option("custom_record_types")
+    CUSTOM_TYPES = _get_config_option("custom_record_types")
 
 
 @initialize_choice_names

--- a/netbox_dns/choices/record.py
+++ b/netbox_dns/choices/record.py
@@ -17,7 +17,9 @@ __all__ = (
 
 
 def _get_config_option(option_name):
-    return get_plugin_config("netbox_dns", option_name, [])
+    return get_plugin_config("netbox_dns", option_name, []) + get_plugin_config(
+        "netbox_dns", f"{option_name}+", []
+    )
 
 
 class RecordTypeNames:


### PR DESCRIPTION
This PR fixes an issue that prevented providing a default value for `filter_record_types` in the plugin configuration and adds a list of record types that are very likely never used, although they are, strictly speaking, RFC compliant.

As a result, the list of record types available in the GUI is much shorter than before, which should make it more convenient to add new records manualls.

In addition, the configuration variable `filter_record_types` was complemented by its cumulative counterpart `filter_record_types+`. If a list of records is specified using the latter variable, it will be added to the types already present in the default list.

Thanks to @jpmens who brought this back to my attention in #541.



