### PR TITLE
Fix detection of invalid double dashes

### DIFF
--- a/netbox_dns/tests/record/test_validation.py
+++ b/netbox_dns/tests/record/test_validation.py
@@ -542,6 +542,18 @@ class RecordValidationTestCase(TestCase):
                 type=RecordTypeChoices.CNAME,
                 value="_name18a.example.com.",
             ),
+            Record(
+                name="2001-e--1",
+                zone=f_zone,
+                type=RecordTypeChoices.AAAA,
+                value="2001:db8:dead:beef::42",
+            ),
+            Record(
+                name="2.4.0.0.0.0.0.0.0.0.0.0.0.0.0.0",
+                zone=r_zone,
+                type=RecordTypeChoices.PTR,
+                value="2001-e--1.zone1.example.com.",
+            ),
         )
 
         for record in records:

--- a/netbox_dns/validators/dns_name.py
+++ b/netbox_dns/validators/dns_name.py
@@ -49,7 +49,7 @@ def _get_label(tolerate_leading_underscores=False, always_tolerant=False):
 
 
 def _has_invalid_double_dash(name):
-    return bool(re.findall(r"\b(?!xn)..--", name, re.IGNORECASE))
+    return bool(re.findall(r"(^|\.)(?!xn)..--", name, re.IGNORECASE))
 
 
 def validate_fqdn(name, always_tolerant=False):


### PR DESCRIPTION
Fixes #613 

This issue uncovered an interesting edge case: 

The detection of invalid double dashes involved checking for a double dash in the third and fourth column after a word boundary. That works for many cases, as the beginning of a label is always a word boundary (beginning of string or '.'), but vice versa a word boundary is not always the beginning of a label.

The example in the issue `2001-e--1.eno1.pve1` has a dash in the fourth column (which constitutes two word boundaries but none is the the beginning of a label), and the first is followed by a substring that has `-e` in the first two columns and `--` in the third and fourth, which is (incorrectly) detected as an invalid double dash.