### PR TITLE
Fix embedded tables

### DIFF
--- a/netbox_dns/tables/view.py
+++ b/netbox_dns/tables/view.py
@@ -57,4 +57,5 @@ class RelatedViewTable(TenancyColumnsMixin, NetBoxTable):
     name = tables.Column(
         linkify=True,
     )
+    tags = TagColumn(url_name="plugins:netbox_dns:view_list")
     actions = ActionsColumn(actions=())

--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -20,6 +20,7 @@ class RelatedDNSRecords(PluginTemplateExtension):
 
     def right_page(self):
         ip_address = self.context.get("object")
+        request = self.context.get("request")
 
         address_records = ip_address.netbox_dns_records.all()
         pointer_records = [
@@ -32,6 +33,7 @@ class RelatedDNSRecords(PluginTemplateExtension):
             address_record_table = RelatedRecordTable(
                 data=address_records,
             )
+            address_record_table.configure(request)
         else:
             address_record_table = None
 
@@ -39,6 +41,7 @@ class RelatedDNSRecords(PluginTemplateExtension):
             pointer_record_table = RelatedRecordTable(
                 data=pointer_records,
             )
+            pointer_record_table.configure(request)
         else:
             pointer_record_table = None
 
@@ -56,11 +59,16 @@ class RelatedDNSViews(PluginTemplateExtension):
 
     def right_page(self):
         prefix = self.context.get("object")
+        request = self.context.get("request")
 
         if assigned_views := prefix.netbox_dns_views.all():
-            context = {"assigned_views": RelatedViewTable(data=assigned_views)}
+            assigned_views_table = RelatedViewTable(data=assigned_views)
+            assigned_views_table.configure(request)
+            context = {"assigned_views": assigned_views_table}
         elif inherited_views := get_views_by_prefix(prefix):
-            context = {"inherited_views": RelatedViewTable(data=inherited_views)}
+            inherited_views_table = RelatedViewTable(data=inherited_views)
+            inherited_views_table.configure(request)
+            context = {"inherited_views": inherited_views_table}
         else:
             context = {}
 
@@ -86,6 +94,7 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
 
     def right_page(self):
         ip_address = self.context.get("object")
+        request = self.context.get("request")
 
         address_records = Record.objects.filter(
             type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA),
@@ -100,6 +109,7 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
             address_record_table = RelatedRecordTable(
                 data=address_records,
             )
+            address_record_table.configure(request)
         else:
             address_record_table = None
 
@@ -107,6 +117,7 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
             pointer_record_table = RelatedRecordTable(
                 data=pointer_records,
             )
+            pointer_record_table.configure(request)
         else:
             pointer_record_table = None
 

--- a/netbox_dns/views/dnssec_key_template.py
+++ b/netbox_dns/views/dnssec_key_template.py
@@ -37,9 +37,9 @@ class DNSSECKeyTemplateView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         if instance.policies.exists():
-            return {
-                "policy_table": DNSSECPolicyDisplayTable(data=instance.policies.all())
-            }
+            policy_table = DNSSECPolicyDisplayTable(data=instance.policies.all())
+            policy_table.configure(request)
+            return {"policy_table": policy_table}
 
         return {}
 

--- a/netbox_dns/views/record.py
+++ b/netbox_dns/views/record.py
@@ -141,11 +141,17 @@ class RecordView(generic.ObjectView):
 
         if instance.type == RecordTypeChoices.CNAME:
             try:
-                context["cname_target_table"] = self.get_value_records(instance)
+                cname_target_table = self.get_value_records(instance)
+                if cname_target_table is not None:
+                    cname_target_table.configure(request)
+                context["cname_target_table"] = cname_target_table
             except CNAMEWarning as exc:
                 context["cname_warning"] = str(exc)
         else:
-            context["cname_table"] = self.get_cname_records(instance)
+            cname_table = self.get_cname_records(instance)
+            if cname_table is not None:
+                cname_table.configure(request)
+            context["cname_table"] = cname_table
 
         if not instance.managed:
             name = dns_name.from_text(instance.name, origin=None)

--- a/netbox_dns/views/record_template.py
+++ b/netbox_dns/views/record_template.py
@@ -50,9 +50,11 @@ class RecordTemplateView(generic.ObjectView):
             context["unicode_value"] = unicode_value
 
         if instance.zone_templates.exists():
-            context["zone_template_table"] = ZoneTemplateDisplayTable(
+            zone_template_table = ZoneTemplateDisplayTable(
                 data=instance.zone_templates.all()
             )
+            zone_template_table.configure(request)
+            context["zone_template_table"] = zone_template_table
 
         return context
 

--- a/netbox_dns/views/zone_template.py
+++ b/netbox_dns/views/zone_template.py
@@ -37,10 +37,12 @@ class ZoneTemplateView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         if instance.record_templates.exists():
+            record_template_table = RecordTemplateDisplayTable(
+                data=instance.record_templates.all()
+            )
+            record_template_table.configure(request)
             return {
-                "record_template_table": RecordTemplateDisplayTable(
-                    data=instance.record_templates.all()
-                )
+                "record_template_table": record_template_table,
             }
 
         return {}


### PR DESCRIPTION
NetBox 4.3 introduced a new feature that makes it possible to re-use table configurations.

As a consequence of this new feature, embedded tables no longer observe the `default_field` settings without being configured on instantiation. This PR does exactly that for all embedded tables used in the plugin.

See https://github.com/netbox-community/netbox/issues/19380 for reference.