### PR TITLE
Update NetBox_DNS_Exporter.py set autoescape=False

### DIFF
--- a/examples/custom-scripts/NetBox_DNS_Exporter.py
+++ b/examples/custom-scripts/NetBox_DNS_Exporter.py
@@ -49,7 +49,7 @@ $TTL {{ zone.default_ttl }}
 {{ record.name.ljust(32) }}    {{ (record.ttl|string if record.ttl is not none else '').ljust(8) }} IN {{ record.type.ljust(8) }}    {{ record.value }}
 {% endfor %}\
 '''
-    jinja_env = Environment(loader=DictLoader({"zone_file": zone_template}), autoescape=True)
+    jinja_env = Environment(loader=DictLoader({"zone_file": zone_template}), autoescape=False)
     template = jinja_env.get_template("zone_file")
 
     def run(self, data, commit):


### PR DESCRIPTION
Setting autoescape = True in jinja2.Environment() leads to converting `"` to `&#34;` when exporting a zone.