### PR TITLE
Fix IPAM DNSsync address deletion

### DIFF
--- a/netbox_dns/utilities/ipam_dnssync.py
+++ b/netbox_dns/utilities/ipam_dnssync.py
@@ -227,10 +227,15 @@ def delete_dns_records(ip_address, view=None):
         # TODO: Find something better. This is really awful.
         # -
         address_records = Record.objects.filter(
-            type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA),
-            managed=True,
-            ip_address=ip_address.address.ip,
-            ipam_ip_address__isnull=True,
+            Q(
+                Q(ipam_ip_address=ip_address)
+                | Q(
+                    type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA),
+                    managed=True,
+                    ip_address=ip_address.address,
+                    ipam_ip_address__isnull=True,
+                )
+            ),
         )
 
     if view is not None:


### PR DESCRIPTION
fixes #668

It appears that the changes in NetBox PR https://github.com/netbox-community/netbox/pull/19681 or https://github.com/netbox-community/netbox/pull/19308 un-broke parts of the `pre_delete` handler NetBox DNS contained a workaround for, and thereby broke the workaround :-)

Until NetBox 4.4 comes around, I made the workaround a bit more complicated so it works independently of whether the fix in NetBox is in place or not.