### PR TITLE
Prepared release 1.3.4

### DIFF
--- a/netbox-plugin.yaml
+++ b/netbox-plugin.yaml
@@ -1,6 +1,9 @@
 version: 0.1
 package_name: netbox-plugin-dns
 compatibility:
+  - release: 1.3.4
+    netbox_min: 4.3.0
+    netbox_max: 4.3.3
   - release: 1.3.3
     netbox_min: 4.3.0
     netbox_max: 4.3.3

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 from netbox.plugins.utils import get_plugin_config
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 
 def _check_list(setting):

--- a/netbox_dns/tests/test_netbox_dns.py
+++ b/netbox_dns/tests/test_netbox_dns.py
@@ -7,7 +7,7 @@ from utilities.testing.api import APITestCase
 
 class NetBoxDNSVersionTestCase(SimpleTestCase):
     def test_version(self):
-        assert __version__ == "1.3.3"
+        assert __version__ == "1.3.4"
 
 
 class AppTest(APITestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-plugin-dns"
-version = "1.3.3"
+version = "1.3.4"
 description = "NetBox DNS is a NetBox plugin for managing DNS data."
 authors = [
     {name="Peter Eckel", email="pete@netbox-dns.org"},


### PR DESCRIPTION
Emergency bugfix release as NetBox 4.3.3 breaks deleting IP addresses linked to DNS records, which is a major malfunction.