### PR TITLE
Add a custom validator that inhibits changing the record type to the examples collection

### DIFF
--- a/examples/custom-validators/README_disable_record_type_change.md
+++ b/examples/custom-validators/README_disable_record_type_change.md
@@ -1,0 +1,31 @@
+# Custom validator to disable changing the type of a DNS record
+
+## Purpose
+
+In [NetBox DNS issue #677](https://github.com/peteeckel/netbox-plugin-dns/issues/677),
+it was suggested to disallow changing the record type. This custom validator adds the
+desired functionality without making changes to the code base.
+
+## Installation
+
+Create a `validators` directory under the NetBox application path and copy this
+validator script into it:
+
+```
+mkdir /opt/netbox/netbox/validators
+cp disable_record_type_change.py /opt/netbox/netbox/validators/
+```
+
+Activate the validator by adding the following lines in `/opt/netbox/netbox/netbox/configuration.py`:
+
+```
+from validators.disable_record_type_change import TypeChangeValidator
+
+CUSTOM_VALIDATORS = {
+    "netbox_dns.record": (
+        TypeChangeValidator(),
+    ),
+}
+```
+
+After making this change, restart NetBox to activate the new validator.

--- a/examples/custom-validators/disable_record_type_change.py
+++ b/examples/custom-validators/disable_record_type_change.py
@@ -1,0 +1,18 @@
+# +
+# Do not allow the type of a record to be changed.
+#
+# This does not affect record creation, but after a record has been created
+# and saved changing the record type is not allowed.
+# -
+
+from extras.validators import CustomValidator
+
+
+class TypeChangeValidator(CustomValidator):
+    def validate(self, record, request):
+        if record._state.adding:
+            return
+
+        saved_type = record._meta.model.objects.get(pk=record.pk).type
+        if record.type != saved_type:
+            self.fail("The record type must not be changed", field="type")


### PR DESCRIPTION
This custom validator example provides a possible solution for the problem described in #677.