### PR TITLE
Use HTMXSelect to de-clutter the UI for some forms

### DIFF
--- a/netbox_dns/forms/dnssec_key_template.py
+++ b/netbox_dns/forms/dnssec_key_template.py
@@ -15,7 +15,8 @@ from utilities.forms.fields import (
     DynamicModelMultipleChoiceField,
 )
 from utilities.forms.rendering import FieldSet
-from utilities.forms import add_blank_choice
+from utilities.forms.widgets import HTMXSelect
+from utilities.forms import add_blank_choice, get_field_value
 from tenancy.models import Tenant, TenantGroup
 from tenancy.forms import TenancyForm, TenancyFilterForm
 
@@ -52,6 +53,10 @@ class DNSSECKeyTemplateForm(TenancyForm, NetBoxModelForm):
             "tags",
         )
 
+        widgets = {
+            "algorithm": HTMXSelect(),
+        }
+
     fieldsets = (
         FieldSet(
             "name",
@@ -75,6 +80,13 @@ class DNSSECKeyTemplateForm(TenancyForm, NetBoxModelForm):
             name=_("Tags"),
         ),
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        algorithm = get_field_value(self, "algorithm")
+        if algorithm != DNSSECKeyTemplateAlgorithmChoices.RSASHA256:
+            del self.fields["key_size"]
 
     lifetime = TimePeriodField(
         required=False,

--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -21,9 +21,13 @@ from utilities.forms.fields import (
     CSVModelMultipleChoiceField,
     DynamicModelChoiceField,
 )
-from utilities.forms.widgets import BulkEditNullBooleanSelect, DatePicker
+from utilities.forms.widgets import BulkEditNullBooleanSelect, DatePicker, HTMXSelect
 from utilities.forms.rendering import FieldSet
-from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES, add_blank_choice
+from utilities.forms import (
+    BOOLEAN_WITH_BLANK_CHOICES,
+    add_blank_choice,
+    get_field_value,
+)
 from tenancy.models import Tenant, TenantGroup
 from tenancy.forms import TenancyForm, TenancyFilterForm
 
@@ -207,6 +211,8 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
         }
 
         widgets = {
+            "dnssec_policy": HTMXSelect(),
+            "registrar": HTMXSelect(),
             "expiration_date": DatePicker,
         }
 
@@ -309,6 +315,15 @@ class ZoneForm(ZoneTemplateUpdateMixin, TenancyForm, NetBoxModelForm):
                 self.initial["nameservers"] = NameServer.objects.filter(
                     name__in=default_nameservers
                 )
+
+        if not get_field_value(self, "dnssec_policy"):
+            del self.fields["inline_signing"]
+            del self.fields["parental_agents"]
+
+        if not get_field_value(self, "registrar"):
+            del self.fields["registry_domain_id"]
+            del self.fields["expiration_date"]
+            del self.fields["domain_status"]
 
     view = DynamicModelChoiceField(
         queryset=View.objects.all(),

--- a/netbox_dns/models/dnssec_key_template.py
+++ b/netbox_dns/models/dnssec_key_template.py
@@ -91,6 +91,9 @@ class DNSSECKeyTemplate(ContactsMixin, NetBoxModel):
         return DNSSECKeyTemplateTypeChoices.colors.get(self.type)
 
     def clean(self, *args, **kwargs):
+        if self.algorithm != DNSSECKeyTemplateAlgorithmChoices.RSASHA256:
+            self.key_size = self._meta.get_field("key_size").get_default()
+
         super().clean(*args, **kwargs)
 
         validate_key_template(self)

--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -800,6 +800,17 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
         super().clean_fields(exclude=exclude)
 
     def clean(self, *args, **kwargs):
+        if not self.dnssec_policy:
+            self.inline_signing = self._meta.get_field("inline_signing").get_default()
+            self.parental_agents = self._meta.get_field("parental_agents").get_default()
+
+        if not self.registrar:
+            self.registry_domain_id = self._meta.get_field(
+                "registry_domain_id"
+            ).get_default()
+            self.expiration_date = self._meta.get_field("expiration_date").get_default()
+            self.domain_status = self._meta.get_field("domain_status").get_default()
+
         if self.soa_ttl is None:
             self.soa_ttl = self.default_ttl
 

--- a/netbox_dns/tests/zone/test_filtersets.py
+++ b/netbox_dns/tests/zone/test_filtersets.py
@@ -174,6 +174,8 @@ class ZoneFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
                 admin_c=cls.contacts[2],
                 billing_c=cls.contacts[2],
                 dnssec_policy=cls.dnssec_policies[2],
+                expiration_date="2026-04-01",
+                domain_status=ZoneEPPStatusChoices.EPP_STATUS_INACTIVE,
             ),
             Zone(
                 name="0.0.10.in-addr.arpa",
@@ -183,8 +185,6 @@ class ZoneFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
                 soa_rname="hostmaster.example.com",
                 soa_serial_auto=True,
                 inline_signing=True,
-                expiration_date="2026-04-01",
-                domain_status=ZoneEPPStatusChoices.EPP_STATUS_INACTIVE,
             ),
             Zone(
                 name="1.0.10.in-addr.arpa",

--- a/netbox_dns/tests/zone/test_views.py
+++ b/netbox_dns/tests/zone/test_views.py
@@ -3,7 +3,7 @@ from datetime import date
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import NameServer, View, Zone
+from netbox_dns.models import NameServer, View, Zone, Registrar
 from netbox_dns.choices import ZoneStatusChoices, ZoneEPPStatusChoices
 
 
@@ -31,6 +31,8 @@ class ZoneViewTestCase(
             NameServer(name="ns3.example.com"),
         )
         NameServer.objects.bulk_create(nameservers)
+
+        registrar = Registrar.objects.create(name="Test Registrar")
 
         zone_data = {
             **Zone.get_defaults(),
@@ -78,6 +80,7 @@ class ZoneViewTestCase(
             "soa_ttl": 43200,
             "soa_minimum": 1800,
             "soa_serial_auto": False,
+            "registrar": registrar.pk,
             "expiration_date": date(2025, 4, 1),
             "domain_status": ZoneEPPStatusChoices.EPP_STATUS_CLIENT_TRANSFER_PROHIBITED,
         }


### PR DESCRIPTION
Using the `HTMXSelect` widgets for choice fields in forms makes it possible to modify the forms' field sets so to reduce the complexity of the form.

This PR uses the technique to remove some fields from zone and DNSSEC key template forms. 