### PR TITLE
Prepared release 4.4.0

### DIFF
--- a/netbox-plugin.yaml
+++ b/netbox-plugin.yaml
@@ -1,15 +1,18 @@
 version: 0.1
 package_name: netbox-plugin-dns
 compatibility:
+  - release: 1.4.0
+    netbox_min: 4.3.2
+    netbox_max: 4.4.0
   - release: 1.3.6
     netbox_min: 4.3.2
-    netbox_max: 4.3.7
+    netbox_max: 4.4.0
   - release: 1.3.5
     netbox_min: 4.3.2
-    netbox_max: 4.3.7
+    netbox_max: 4.4.0
   - release: 1.3.4
     netbox_min: 4.3.2
-    netbox_max: 4.3.7
+    netbox_max: 4.4.0
   - release: 1.3.3
     netbox_min: 4.3.2
     netbox_max: 4.3.2

--- a/netbox_dns/__init__.py
+++ b/netbox_dns/__init__.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from netbox.plugins import PluginConfig
 from netbox.plugins.utils import get_plugin_config
 
-__version__ = "1.3.6"
+__version__ = "1.4.0"
 
 
 def _check_list(setting):

--- a/netbox_dns/tests/test_netbox_dns.py
+++ b/netbox_dns/tests/test_netbox_dns.py
@@ -7,7 +7,7 @@ from utilities.testing.api import APITestCase
 
 class NetBoxDNSVersionTestCase(SimpleTestCase):
     def test_version(self):
-        assert __version__ == "1.3.6"
+        assert __version__ == "1.4.0"
 
 
 class AppTest(APITestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-plugin-dns"
-version = "1.3.6"
+version = "1.4.0"
 description = "NetBox DNS is a NetBox plugin for managing DNS data."
 authors = [
     {name="Peter Eckel", email="pete@netbox-dns.org"},


### PR DESCRIPTION
This is a minor release, mainly to keep in sync with NetBox minor release 4.4.0.

NetBox 4.3.2 and higher are still supported as the 4.4.0 release did not provide any breaking changes.