### PR TITLE
Removed the legacy "changelog" action from the zone view

### DIFF
--- a/netbox_dns/views/zone.py
+++ b/netbox_dns/views/zone.py
@@ -157,7 +157,6 @@ class ZoneManagedRecordListView(generic.ObjectChildrenView):
     table = ManagedRecordTable
     filterset = RecordFilterSet
     template_name = "netbox_dns/zone/managed_record.html"
-    actions = {"changelog": {"view"}}
 
     tab = ViewTab(
         label=_("Managed Records"),


### PR DESCRIPTION
fixes #703

This shouldn't have happened, as there were no breaking changes announced for NetBox 4.4.0 ... but anyway.

Removed the legacy action from the zone's `ZoneManagedRecordListView`.