### PR TITLE
Implemented accessibility tests for viewtabs of detail views

### DIFF
--- a/netbox_dns/tests/nameserver/test_views.py
+++ b/netbox_dns/tests/nameserver/test_views.py
@@ -1,7 +1,7 @@
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import NameServer
+from netbox_dns.models import NameServer, Zone
 
 
 class NameServerViewTestCase(
@@ -53,3 +53,45 @@ class NameServerViewTestCase(
         )
 
     maxDiff = None
+
+    def test_zones_viewtab(self):
+        soa_nameserver = self.nameservers[0]
+        nameserver = self.nameservers[1]
+
+        zone = Zone.objects.create(
+            name="zone1.example.com",
+            soa_mname=soa_nameserver,
+            soa_rname="hostmaster.example.com",
+        )
+        zone.nameservers.set([nameserver])
+
+        self.add_permissions(
+            "netbox_dns.view_nameserver",
+        )
+
+        request = {
+            "path": self._get_url("zones", instance=nameserver),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_soa_zones_viewtab(self):
+        soa_nameserver = self.nameservers[0]
+
+        Zone.objects.create(
+            name="zone1.example.com",
+            soa_mname=soa_nameserver,
+            soa_rname="hostmaster.example.com",
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_nameserver",
+        )
+
+        request = {
+            "path": self._get_url("soa_zones", instance=soa_nameserver),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)

--- a/netbox_dns/tests/registrar/test_views.py
+++ b/netbox_dns/tests/registrar/test_views.py
@@ -1,7 +1,7 @@
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import Registrar
+from netbox_dns.models import Registrar, NameServer, Zone
 
 
 class RegistrarViewTestCase(
@@ -74,3 +74,25 @@ class RegistrarViewTestCase(
         )
 
     maxDiff = None
+
+    def test_zones_viewtab(self):
+        registrar = self.registrars[0]
+
+        nameserver = NameServer.objects.create(name="ns1.example.com")
+        Zone.objects.create(
+            name="zone1.example.com",
+            soa_mname=nameserver,
+            soa_rname="hostmaster.example.com",
+            registrar=registrar,
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_registrar",
+        )
+
+        request = {
+            "path": self._get_url("zones", instance=registrar),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)

--- a/netbox_dns/tests/registration_contact/test_views.py
+++ b/netbox_dns/tests/registration_contact/test_views.py
@@ -1,7 +1,7 @@
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import RegistrationContact
+from netbox_dns.models import RegistrationContact, NameServer, Zone
 
 
 class RegistrationContactViewTestCase(
@@ -69,3 +69,25 @@ class RegistrationContactViewTestCase(
         )
 
     maxDiff = None
+
+    def test_zones_viewtab(self):
+        contact = self.contacts[0]
+
+        nameserver = NameServer.objects.create(name="ns1.example.com")
+        Zone.objects.create(
+            name="zone1.example.com",
+            soa_mname=nameserver,
+            soa_rname="hostmaster.example.com",
+            registrant=contact,
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_registrationcontact",
+        )
+
+        request = {
+            "path": self._get_url("zones", instance=contact),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)

--- a/netbox_dns/tests/zone/test_views.py
+++ b/netbox_dns/tests/zone/test_views.py
@@ -3,8 +3,12 @@ from datetime import date
 from utilities.testing import ViewTestCases, create_tags
 
 from netbox_dns.tests.custom import ModelViewTestCase
-from netbox_dns.models import NameServer, View, Zone, Registrar
-from netbox_dns.choices import ZoneStatusChoices, ZoneEPPStatusChoices
+from netbox_dns.models import NameServer, View, Zone, Record, Registrar
+from netbox_dns.choices import (
+    ZoneStatusChoices,
+    ZoneEPPStatusChoices,
+    RecordTypeChoices,
+)
 
 
 class ZoneViewTestCase(
@@ -32,9 +36,9 @@ class ZoneViewTestCase(
         )
         NameServer.objects.bulk_create(nameservers)
 
-        registrar = Registrar.objects.create(name="Test Registrar")
+        cls.registrar = Registrar.objects.create(name="Test Registrar")
 
-        zone_data = {
+        cls.zone_data = {
             **Zone.get_defaults(),
             "soa_mname": nameservers[0],
             "soa_rname": "hostmaster.example.com",
@@ -48,12 +52,12 @@ class ZoneViewTestCase(
         View.objects.bulk_create(views)
 
         default_view = View.get_default_view()
-        zones = (
-            Zone(name="zone1.example.com", **zone_data),
-            Zone(name="zone2.example.com", **zone_data),
-            Zone(name="zone3.example.com", **zone_data),
+        cls.zones = (
+            Zone(name="zone1.example.com", **cls.zone_data),
+            Zone(name="zone2.example.com", **cls.zone_data),
+            Zone(name="zone3.example.com", **cls.zone_data),
         )
-        for zone in zones:
+        for zone in cls.zones:
             zone.save()
 
         tags = create_tags("Alpha", "Bravo", "Charlie")
@@ -61,7 +65,7 @@ class ZoneViewTestCase(
         cls.form_data = {
             "name": "zone7.example.com",
             "status": ZoneStatusChoices.STATUS_PARKED,
-            **zone_data,
+            **cls.zone_data,
             "view": default_view.pk,
             "soa_mname": nameservers[0].pk,
             "tags": [t.pk for t in tags],
@@ -80,7 +84,7 @@ class ZoneViewTestCase(
             "soa_ttl": 43200,
             "soa_minimum": 1800,
             "soa_serial_auto": False,
-            "registrar": registrar.pk,
+            "registrar": cls.registrar.pk,
             "expiration_date": date(2025, 4, 1),
             "domain_status": ZoneEPPStatusChoices.EPP_STATUS_CLIENT_TRANSFER_PROHIBITED,
         }
@@ -95,6 +99,137 @@ class ZoneViewTestCase(
 
         cls.csv_update_data = (
             "id,status,description,view,nameservers,domain_status",
-            f"{zones[0].pk},{ZoneStatusChoices.STATUS_PARKED},test-zone1,,{nameservers[1].name},{ZoneEPPStatusChoices.EPP_STATUS_OK}",
-            f'{zones[1].pk},{ZoneStatusChoices.STATUS_ACTIVE},test-zone2,{views[0].name},"{nameservers[1].name},{nameservers[2].name}",',
+            f"{cls.zones[0].pk},{ZoneStatusChoices.STATUS_PARKED},test-zone1,,{nameservers[1].name},{ZoneEPPStatusChoices.EPP_STATUS_OK}",
+            f'{cls.zones[1].pk},{ZoneStatusChoices.STATUS_ACTIVE},test-zone2,{views[0].name},"{nameservers[1].name},{nameservers[2].name}",',
         )
+
+    def test_records_viewtab(self):
+        zone = self.zones[0]
+
+        Record.objects.create(
+            name="test",
+            zone=zone,
+            type=RecordTypeChoices.AAAA,
+            value="2001:db8::42",
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("records", instance=zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_registration_viewtab(self):
+        zone = self.zones[0]
+        zone.registrar = self.registrar
+        zone.save()
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("registration", instance=zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_managed_records_viewtab(self):
+        zone = self.zones[0]
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("managed_records", instance=zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_delegation_records_viewtab(self):
+        zone = self.zones[0]
+
+        Zone.objects.create(name=f"sub.{zone.name}", **self.zone_data)
+        Record.objects.create(
+            name="sub",
+            zone=zone,
+            type=RecordTypeChoices.NS,
+            value=f"ns1.sub.{zone.name}",
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("delegation_records", instance=zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_parent_delegation_records_viewtab(self):
+        zone = self.zones[0]
+
+        child_zone = Zone.objects.create(name=f"sub.{zone.name}", **self.zone_data)
+        Record.objects.create(
+            name="sub",
+            zone=zone,
+            type=RecordTypeChoices.NS,
+            value=f"ns1.sub.{zone.name}",
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("parent_delegation_records", instance=child_zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_rfc2317_child_zones_viewtab(self):
+        zone = Zone.objects.create(name="0.168.192.in-addr.arpa", **self.zone_data)
+        Zone.objects.create(
+            name="0-15.0.168.192.in-addr.arpa",
+            **self.zone_data,
+            rfc2317_prefix="192.168.0.0/28",
+            rfc2317_parent_managed=True,
+        )
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("rfc2317_child_zones", instance=zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)
+
+    def test_child_zones_viewtab(self):
+        zone = self.zones[0]
+
+        child_zone = Zone.objects.create(name=f"sub.{zone.name}", **self.zone_data)
+
+        self.add_permissions(
+            "netbox_dns.view_zone",
+        )
+
+        request = {
+            "path": self._get_url("child_zones", instance=child_zone),
+        }
+
+        response = self.client.get(**request)
+        self.assertHttpStatus(response, 200)


### PR DESCRIPTION
Check the accessibility of all view tabs for the following models:

* DNSSECPolicy
* NameServer
* Registrar
* RegistrationContact
* View
* Zone

These tests would have detected (among potential other similar issues) the problem reported in #703.