### PR TITLE
Performance improvement when creating or updating reverse zones

### DIFF
--- a/netbox_dns/models/zone.py
+++ b/netbox_dns/models/zone.py
@@ -978,9 +978,14 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
                 record_type = RecordTypeChoices.AAAA
 
             address_records = Record.objects.filter(
-                Q(ptr_record__isnull=True, zone__view=self.view)
+                Q(
+                    ptr_record__isnull=True,
+                    zone__view=self.view,
+                    ip_address__isnull=False,
+                    ip_address__contained=self.arpa_network,
+                    type=record_type,
+                )
                 | Q(ptr_record__zone__in=zones),
-                type=record_type,
                 disable_ptr=False,
             )
 
@@ -1009,7 +1014,7 @@ class Zone(ObjectModificationMixin, ContactsMixin, NetBoxModel):
                 arpa_network__net_contains=self.rfc2317_prefix
             )
             address_records = Record.objects.filter(
-                Q(ptr_record__isnull=True)
+                Q(ptr_record__isnull=True, ip_address__contained=self.rfc2317_prefix)
                 | Q(ptr_record__zone__in=zones)
                 | Q(ptr_record__zone=self),
                 type=RecordTypeChoices.A,


### PR DESCRIPTION
When a new reverse zone was created or the name, view or status of an existing one was updated, formerly all A and AAAA records that did not have a PTR record were checked for a PTR record in the new or updated zone.

This was a major performance hit and could be - in some cases, drastically - reduced by two measures:

* Check for the IP family of the zone and check only A or only AAAA records without PTR
* Check only records whose "ip_address" field falls into the new zone's "arpa_network" or "rfc2317_prefix".

Especially the second measure should speed up the creation of new reverse zones, especially in environments with many address records.