### PR TITLE
add missing object types to the list

### DIFF
--- a/docs/using_netbox_dns.md
+++ b/docs/using_netbox_dns.md
@@ -144,7 +144,7 @@ NetBox 3.5.0 up to NetBox 3.7.x are not supported by the latest version of NetBo
 ```
 
 ## Object types
-Currently NetBox DNS can manage eight different object types: Views, Name Servers, Zone Templates, Zones, Record Templates, Records, Registration Contacts and Registrars.
+Currently NetBox DNS can manage ten different object types: Views, Name Servers, Zones, Records, Zone Templates, Record Templates, DNSSEC Key Templates, DNSSEC Policies, Registrars, and Registration Contacts.
 
 For all fields that contain time periods (record TTL and the zone SOA timer fields, just to name a few) there is an alternative way of entering values. Instead of having to convert the desired value to seconds, NetBox DNS supports a subset of the ISO 8601 duration format starting with version 1.2.6. To specify a TTL of one day, the format "P1D" is accepted, which will be converted to 86400 before being written to the database. A time period of 15 hours is written as "PT15H" (the "T" means that the remaining part of the string represents time, not date) is interpreted as 54000. All letters have to be uppercase.
 


### PR DESCRIPTION
`s/eight/ten/` on the object types and order them as they appear by default in the menu.