### PR TITLE
Improved interoperability between IPAM DNSsync and heuristic record detection

### DIFF
--- a/netbox_dns/template_content.py
+++ b/netbox_dns/template_content.py
@@ -48,8 +48,18 @@ class RelatedDNSRecords(PluginTemplateExtension):
         return self.render(
             "netbox_dns/record/related.html",
             extra_context={
-                "related_address_records": address_record_table,
-                "related_pointer_records": pointer_record_table,
+                "address_card_title": (
+                    _("Synchronized Address Records")
+                    if len(address_records) > 1
+                    else _("Synchronized Address Record")
+                ),
+                "address_record_table": address_record_table,
+                "pointer_card_title": (
+                    _("Synchronized Pointer Records")
+                    if len(pointer_records) > 1
+                    else _("Synchronized Pointer Record")
+                ),
+                "pointer_record_table": pointer_record_table,
             },
         )
 
@@ -99,11 +109,11 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
         address_records = Record.objects.filter(
             type__in=(RecordTypeChoices.A, RecordTypeChoices.AAAA),
             ip_address=ip_address.address.ip,
-        )
+        ).exclude(ipam_ip_address=ip_address)
         pointer_records = Record.objects.filter(
             type=RecordTypeChoices.PTR,
             ip_address=ip_address.address.ip,
-        )
+        ).exclude(address_records__ipam_ip_address__in=[ip_address])
 
         if address_records:
             address_record_table = RelatedRecordTable(
@@ -124,8 +134,18 @@ class IPRelatedDNSRecords(PluginTemplateExtension):
         return self.render(
             "netbox_dns/record/related.html",
             extra_context={
-                "related_address_records": address_record_table,
-                "related_pointer_records": pointer_record_table,
+                "address_card_title": (
+                    _("Related Address Records")
+                    if len(address_records) > 1
+                    else _("Related Address Record")
+                ),
+                "address_record_table": address_record_table,
+                "pointer_card_title": (
+                    _("Related Pointer Records")
+                    if len(pointer_records) > 1
+                    else _("Related Pointer Record")
+                ),
+                "pointer_record_table": pointer_record_table,
             },
         )
 

--- a/netbox_dns/templates/netbox_dns/record/related.html
+++ b/netbox_dns/templates/netbox_dns/record/related.html
@@ -1,29 +1,20 @@
 {% load render_table from django_tables2 %}
 {% load perms %}
-{% load i18n %}
 
 {% if perms.netbox_dns.view_record %}
-    {% if related_address_records %}
+    {% if address_record_table %}
         <div class="card">
-            {% if related_address_records.rows|length == 1 %}
-                <h2 class="card-header">{% trans "Related DNS Address Record" %}</h2>
-            {% else %}
-                <h2 class="card-header">{% trans "Related DNS Address Records" %}</h2>
-            {% endif %}
+            <h2 class="card-header">{{ address_card_title }}</h2>
             <div class="table-responsive">
-                {% render_table related_address_records 'inc/table.html' %}
+                {% render_table address_record_table 'inc/table.html' %}
             </div>
         </div>
     {% endif %}
-    {% if related_pointer_records %}
+    {% if pointer_record_table %}
         <div class="card">
-            {% if related_pointer_records.rows|length == 1 %}
-                <h2 class="card-header">{% trans "Related DNS Pointer Record" %}</h2>
-            {% else %}
-                <h2 class="card-header">{% trans "Related DNS Pointer Records" %}</h2>
-            {% endif %}
+            <h2 class="card-header">{{ pointer_card_title }}</h2>
             <div class="table-responsive">
-                {% render_table related_pointer_records 'inc/table.html' %}
+                {% render_table pointer_record_table 'inc/table.html' %}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
This PR is the result of a discussion with @HB9HIL.

As a replacement for the time until I find the time to implement the feature described in Discussion #493 I suggested using the `feature_ipam_dns_info` flag. One issue with that is that it displays records created via IPAM DNSsync as well, which doesen't make much sense - it just wasn't designed to be used alongside DNSsync.

This PR modifies the list of (potentially) related DNS records displayed by the feature in such a way that it does no longer list records created by DNSsync. Slight changes to the table headings reflect the different approach.