### PR TITLE
Removed unused `records` prefetch from the `Zone` serializer

### DIFF
--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -63,7 +63,6 @@ class ZoneViewSet(NetBoxModelViewSet):
         "nameservers",
         "tags",
         "soa_mname",
-        "records",
         "tenant",
     )
     serializer_class = ZoneSerializer


### PR DESCRIPTION
This is a replacement for PR #746.

Prefetching the records does not make any sense in the `Zone` serializer as the field is not used, and it takes up a comparably long time that can be saved by just removing the prefetch. This does not have any negative implications at all. 

Thanks @amir-bakar for spotting this issue!