### PR TITLE
Further reduced prefetch columns for API views

### DIFF
--- a/netbox_dns/api/views.py
+++ b/netbox_dns/api/views.py
@@ -58,25 +58,19 @@ class ViewViewSet(NetBoxModelViewSet):
 
 
 class ZoneViewSet(NetBoxModelViewSet):
-    queryset = Zone.objects.prefetch_related(
-        "view",
-        "nameservers",
-        "tags",
-        "soa_mname",
-        "tenant",
-    )
+    queryset = Zone.objects.prefetch_related("view", "nameservers", "soa_mname")
     serializer_class = ZoneSerializer
     filterset_class = ZoneFilterSet
 
 
 class NameServerViewSet(NetBoxModelViewSet):
-    queryset = NameServer.objects.prefetch_related("zones", "tenant")
+    queryset = NameServer.objects.prefetch_related("zones")
     serializer_class = NameServerSerializer
     filterset_class = NameServerFilterSet
 
 
 class RecordViewSet(NetBoxModelViewSet):
-    queryset = Record.objects.prefetch_related("zone", "zone__view", "tenant")
+    queryset = Record.objects.prefetch_related("zone", "zone__view")
     serializer_class = RecordSerializer
     filterset_class = RecordFilterSet
 


### PR DESCRIPTION
Minimized the number of prefetched columns for API requests to the bare minimum. 

This is a tradeoff between the number of database queries and the response time of the API in more complex situations, especially when the `brief` option is used, in which case many of the pre-fetched columns aren't used at all. 