### PR TITLE
feat: add plugin extension to DNS view templates #770

### DIFF
--- a/netbox_dns/templates/netbox_dns/dnsseckeytemplate.html
+++ b/netbox_dns/templates/netbox_dns/dnsseckeytemplate.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load render_table from django_tables2 %}
 {% load i18n %}
 
@@ -49,9 +50,11 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
+            {% plugin_right_page object %}
         </div>
     </div>
     {% if policy_table %}
@@ -68,4 +71,9 @@
             </div>
         </div>
     {% endif %}
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
+        </div>
+    </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/dnssecpolicy.html
+++ b/netbox_dns/templates/netbox_dns/dnssecpolicy.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load i18n %}
 
 {% block content %}
@@ -101,6 +102,7 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
@@ -159,6 +161,12 @@
                     {% endif %}
                 </table>
             </div>
+            {% plugin_right_page object %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
         </div>
     </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/nameserver.html
+++ b/netbox_dns/templates/netbox_dns/nameserver.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load i18n %}
 
 {% block content %}
@@ -38,9 +39,17 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
+            {% plugin_right_page object %}
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
         </div>
     </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/record.html
+++ b/netbox_dns/templates/netbox_dns/record.html
@@ -175,13 +175,19 @@
         {% if not object.managed %}
         {% include 'inc/panels/custom_fields.html' %}
         {% include 'inc/panels/comments.html' %}
+        {% plugin_left_page object %}
         {% endif %}
     </div>
     {% if not object.managed %}
     <div class="col col-md-4">
         {% include 'inc/panels/tags.html' %}
     </div>
+    {% plugin_right_page object %}
     {% endif %}
 </div>
-
+<div class="row">
+    <div class="col col-md-12">
+        {% plugin_full_width_page object %}
+    </div>
+</div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/recordtemplate.html
+++ b/netbox_dns/templates/netbox_dns/recordtemplate.html
@@ -74,9 +74,11 @@
         </div>
         {% include 'inc/panels/custom_fields.html' %}
         {% include 'inc/panels/comments.html' %}
+        {% plugin_left_page object %}
     </div>
     <div class="col col-md-4">
         {% include 'inc/panels/tags.html' %}
+        {% plugin_right_page object %}
     </div>
     {% if zone_template_table %}
         <div class="col col-md-12">
@@ -93,5 +95,9 @@
         </div>
     {% endif %}
 </div>
-
+<div class="row">
+    <div class="col col-md-12">
+        {% plugin_full_width_page object %}
+    </div>
+</div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/registrar.html
+++ b/netbox_dns/templates/netbox_dns/registrar.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load i18n %}
 
 {% block content %}
@@ -50,9 +51,16 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
+            {% plugin_right_page object %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
         </div>
     </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/registrationcontact.html
+++ b/netbox_dns/templates/netbox_dns/registrationcontact.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load i18n %}
 
 {% block content %}
@@ -69,9 +70,16 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
+            {% plugin_right_page object %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
         </div>
     </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/view.html
+++ b/netbox_dns/templates/netbox_dns/view.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load i18n %}
 
 {% block content %}
@@ -36,6 +37,7 @@
             </div>
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}
+            {% plugin_left_page object %}
         </div>
         <div class="col col-md-6">
             {% include 'inc/panels/tags.html' %}
@@ -76,6 +78,12 @@
                 </div>
             </div>
             {% endif %}
+            {% plugin_right_page object %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col-md-12">
+            {% plugin_full_width_page object %}
         </div>
     </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/zone.html
+++ b/netbox_dns/templates/netbox_dns/zone.html
@@ -1,4 +1,5 @@
 {% extends 'netbox_dns/zone/base.html' %}
+{% load plugins %}
 {% load helpers %}
 {% load i18n %}
 {% load netbox_dns %}
@@ -121,6 +122,7 @@
         {% include 'inc/panels/tags.html' %}
         {% include 'inc/panels/custom_fields.html' %}
         {% include 'inc/panels/comments.html' %}
+        {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
         <div class="card">
@@ -203,6 +205,12 @@
             </div>
         </div>
         {% endif %}
+        {% plugin_right_page object %}
+    </div>
+</div>
+<div class="row">
+    <div class="col col-md-12">
+        {% plugin_full_width_page object %}
     </div>
 </div>
 {% endblock %}

--- a/netbox_dns/templates/netbox_dns/zonetemplate.html
+++ b/netbox_dns/templates/netbox_dns/zonetemplate.html
@@ -78,6 +78,7 @@
         {% include 'inc/panels/custom_fields.html' %}
         {% include 'inc/panels/tags.html' %}
         {% include 'inc/panels/comments.html' %}
+        {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
         <div class="card">
@@ -121,5 +122,11 @@
             </div>
         </div>
     {% endif %}
+    {% plugin_right_page object %}
+</div>
+<div class="row">
+    <div class="col col-md-12">
+        {% plugin_full_width_page object %}
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Add plugin hook support to DNS object detail templates to allow plugins to inject custom content. This enables third-party plugins to extend the UI by adding content to left panel, right panel, and full-width sections of detail views.

Changes:
- Load plugins template library in all DNS object templates
- Add plugin_left_page hook to left column sections
- Add plugin_right_page hook to right column sections
- Add plugin_full_width_page hook in new full-width row at bottom

Affected templates: dnsseckeytemplate, dnssecpolicy, nameserver, record, recordtemplate, registrar, and others.