### PR TITLE
Remove owner_group from zone templates before applying

### DIFF
--- a/netbox_dns/forms/zone.py
+++ b/netbox_dns/forms/zone.py
@@ -119,6 +119,7 @@ class ZoneTemplateUpdateMixin:
 
                     zone_data.pop("template", None)
                     zone_data.pop("tenant_group", None)
+                    zone_data.pop("owner_group", None)
                     zone_data.pop("_init_time", None)
 
                     nameservers = zone_data.pop("nameservers")


### PR DESCRIPTION
fixes #776

Similar to `tenant_group`, `owner_group` is not a model field and needs to be removed when applying zone templates.